### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 tickadoo® MCP Server brings live experience discovery to AI assistants through the Model Context Protocol (MCP). It gives compatible clients access to bookable theatre, shows, tours, attractions, and events across 700+ cities worldwide.
 
+[![tickadoo MCP server](https://glama.ai/mcp/servers/tickadoo/tickadoo-mcp/badges/card.svg)](https://glama.ai/mcp/servers/tickadoo/tickadoo-mcp)
+
 Current release: `v1.1.0`
 
 - 4 read-only MCP tools


### PR DESCRIPTION
This PR adds a badge for the [tickadoo](https://glama.ai/mcp/servers/tickadoo/tickadoo-mcp) server listing in Glama MCP server directory.

[![tickadoo MCP server](https://glama.ai/mcp/servers/tickadoo/tickadoo-mcp/badges/card.svg)](https://glama.ai/mcp/servers/tickadoo/tickadoo-mcp)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.