### PR TITLE
feat(mcp-apps): add experience-card and experience-map UI resources (GRO-229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.0] - 2026-04-18
+### Added
+- MCP Apps support (GRO-229): `experience-card` and `experience-map` UI resources wired into `get_experience_details` and `find_nearby_experiences` via `_meta.ui.resourceUri`, with `openai/outputTemplate` fallback for ChatGPT Apps. Conforming clients (Claude, ChatGPT Apps, Goose, VS Code) render interactive booking cards and price-pin maps inline; non-conforming clients see the normal text and structured response. Zero new npm dependencies; Leaflet 1.9.4 is loaded from cdnjs with SRI hashes only inside the experience-map iframe.
+- `tests/ui-resources.test.ts` covering URI exports, resource registration shape, and required HTML markers.
+
 ## [1.4.1] - 2026-03-30
 ### Added
 - `get_travel_tips` MCP tool for local insider advice across 20 launch cities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## [1.5.0] - 2026-04-18
 ### Added
 - MCP Apps support (GRO-229): `experience-card` and `experience-map` UI resources wired into `get_experience_details` and `find_nearby_experiences` via `_meta.ui.resourceUri`, with `openai/outputTemplate` fallback for ChatGPT Apps. Conforming clients (Claude, ChatGPT Apps, Goose, VS Code) render interactive booking cards and price-pin maps inline; non-conforming clients see the normal text and structured response. Zero new npm dependencies; Leaflet 1.9.4 is loaded from cdnjs with SRI hashes only inside the experience-map iframe.
-- `tests/ui-resources.test.ts` covering URI exports, resource registration shape, and required HTML markers.
+- Resources served with the MCP Apps standard MIME type `text/html;profile=mcp-app` (exported as `MCP_APP_MIME_TYPE`). Hosts only enable the sandbox bridge for this exact MIME, so plain `text/html` would not render inline.
+- Per-resource `_meta.ui` metadata: `prefersBorder: false` on the card (it styles its own border), `prefersBorder: true` plus a CSP `resourceDomains` allowlist on the map for `https://cdnjs.cloudflare.com` and the four CARTO basemap subdomains.
+- Optional ChatGPT `openai/toolInvocation/invoking` and `openai/toolInvocation/invoked` hints on both tool descriptors (ignored safely by conforming MCP Apps clients).
+- UTM attribution on every booking URL emitted by the widgets (`utm_source=mcp`, `utm_medium=mcp-app`, `utm_campaign=experience-card|experience-map`) so bookings originating in Claude / ChatGPT / Goose are attributable in web analytics.
+- `tests/ui-resources.test.ts` covering URI exports, standard MIME type, registration shape, dual-key `uiMeta` payload, optional invocation hints, CSP allowlist, UTM markers, and required HTML markers.
 
 ## [1.4.1] - 2026-03-30
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tickadoo/mcp-server",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tickadoo/mcp-server",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -23,6 +23,9 @@
         "typescript": "^5.9.3",
         "vitest": "^4.1.0",
         "wrangler": "^4.14.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tickadoo/mcp-server",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "tickadoo MCP Server -- 14 AI-powered tools for discovering and booking 13,090+ experiences across 700+ cities. Agent intelligence layer with best picks, price tiers, mood search, city guides, family planners, and booking urgency signals. No API key required.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -1,6 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
+  EXPERIENCE_CARD_URI,
+  EXPERIENCE_MAP_URI,
+  registerTickadooUiResources,
+  uiMeta,
+} from "./ui-resources.js";
+import {
   buildAvailabilityCheckPayload,
   calculateAvailabilityWindowDays,
   CHECK_AVAILABILITY_NEXT_STEP_HINT,
@@ -3408,7 +3414,7 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
     }),
   );
 
-  server.tool(
+  const nearbyTool = server.tool(
     "find_nearby_experiences",
     `Find shows, events and experiences near a geographic location on tickadoo. Supports optional date filtering with dateFrom/dateTo. ${LANGUAGE_SUPPORT_NOTE} Use when a user shares their location or asks for things to do near them.`,
     {
@@ -3535,6 +3541,8 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
       }
     }),
   );
+
+  nearbyTool.update({ _meta: uiMeta(EXPERIENCE_MAP_URI) });
 
   server.tool(
     "list_cities",
@@ -3913,7 +3921,7 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
     }),
   );
 
-  server.tool(
+  const detailsTool = server.tool(
     "get_experience_details",
     `Get detailed availability, venue details, and images for a specific tickadoo experience. Prefer passing the tickadoo slug or booking URL path; provider and provider_id are legacy fallback inputs. ${LANGUAGE_SUPPORT_NOTE}`,
     {
@@ -4001,6 +4009,8 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
       }
     }),
   );
+
+  detailsTool.update({ _meta: uiMeta(EXPERIENCE_CARD_URI) });
 
   server.tool(
     "compare_experiences",
@@ -4368,5 +4378,6 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
     }),
   );
 
+  registerTickadooUiResources(server);
   return server;
 }

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -3542,7 +3542,12 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
     }),
   );
 
-  nearbyTool.update({ _meta: uiMeta(EXPERIENCE_MAP_URI) });
+  nearbyTool.update({
+    _meta: uiMeta(EXPERIENCE_MAP_URI, {
+      invoking: "Searching tickadoo nearby…",
+      invoked: "Map ready",
+    }),
+  });
 
   server.tool(
     "list_cities",
@@ -4010,7 +4015,12 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
     }),
   );
 
-  detailsTool.update({ _meta: uiMeta(EXPERIENCE_CARD_URI) });
+  detailsTool.update({
+    _meta: uiMeta(EXPERIENCE_CARD_URI, {
+      invoking: "Loading experience…",
+      invoked: "Details ready",
+    }),
+  });
 
   server.tool(
     "compare_experiences",

--- a/src/shared/ui-resources.ts
+++ b/src/shared/ui-resources.ts
@@ -1,0 +1,717 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * MCP Apps UI resources served by the tickadoo MCP server.
+ *
+ * Conforming clients (Claude, ChatGPT Apps, Goose, VS Code) inspect the
+ * `_meta.ui.resourceUri` field on a tool result and render the matching
+ * UI resource inline. Non-conforming clients ignore `_meta.ui` and fall
+ * back to the tool's normal text / structuredContent output, so this is
+ * fully additive.
+ *
+ * HTML is kept as inline `String.raw` template literals so the module
+ * works identically under Node, Cloudflare Workers, and Vercel Edge with
+ * no bundler plugin and no runtime fs access. The only external asset
+ * is Leaflet 1.9.4, pinned to a specific cdnjs URL with SRI hashes, and
+ * loaded only inside the experience-map iframe.
+ *
+ * GRO-229.
+ */
+
+export const EXPERIENCE_CARD_URI = "ui://tickadoo/experience-card.html";
+export const EXPERIENCE_MAP_URI = "ui://tickadoo/experience-map.html";
+
+/**
+ * Build the `_meta` payload that wires a tool to one of these UI
+ * resources. The dual key shape (`ui.resourceUri` + `openai/outputTemplate`)
+ * lets one declaration light up Claude/Goose/VS Code (MCP Apps spec) and
+ * ChatGPT Apps simultaneously, with neither client breaking on the other's
+ * key.
+ */
+export function uiMeta(uri: string): {
+  ui: { resourceUri: string };
+  "openai/outputTemplate": string;
+} {
+  return {
+    ui: { resourceUri: uri },
+    "openai/outputTemplate": uri,
+  };
+}
+
+interface UiResourceSpec {
+  readonly name: string;
+  readonly uri: string;
+  readonly description: string;
+  readonly html: string;
+}
+
+const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>tickadoo experience</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #0f1115;
+    --muted: #5a6172;
+    --line: #e6e8ee;
+    --card: #ffffff;
+    --gold: #c69b3d;
+    --gold-fg: #1a1305;
+    --accent: #0f1115;
+    --accent-fg: #ffffff;
+    --pop-bg: #fff7e3;
+    --pop-fg: #6b4a05;
+    --urg-bg: #fdecec;
+    --urg-fg: #8a1f1f;
+    --chip-bg: #f3f4f8;
+    --chip-fg: #2a2f3a;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1016;
+      --fg: #ecedf1;
+      --muted: #98a0b3;
+      --line: #1f2330;
+      --card: #141823;
+      --gold: #d6ad55;
+      --gold-fg: #1a1305;
+      --accent: #ecedf1;
+      --accent-fg: #0d1016;
+      --pop-bg: #2a2113;
+      --pop-fg: #f1d692;
+      --urg-bg: #2a1515;
+      --urg-fg: #f7b3b3;
+      --chip-bg: #1d2230;
+      --chip-fg: #d8dbe4;
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 14px;
+    overflow: hidden; max-width: 560px; margin: 12px auto; }
+  .hero { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; background: #11141c; }
+  .body { padding: 14px 16px 4px; }
+  .badges { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; min-height: 0; }
+  .badge { display: inline-flex; align-items: center; gap: 4px; padding: 3px 8px;
+    border-radius: 999px; font-size: 11px; font-weight: 600; letter-spacing: 0.01em; }
+  .badge--popular { background: var(--pop-bg); color: var(--pop-fg); }
+  .badge--urgent { background: var(--urg-bg); color: var(--urg-fg); }
+  .title { font-size: 17px; font-weight: 600; line-height: 1.25; margin: 0 0 6px; }
+  .meta { color: var(--muted); font-size: 12px; margin: 0 0 10px;
+    display: flex; gap: 10px; flex-wrap: wrap; }
+  .meta span { white-space: nowrap; }
+  .desc { color: var(--fg); opacity: 0.85; margin: 0 0 12px;
+    display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+  .tags { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+  .tag { background: var(--chip-bg); color: var(--chip-fg); font-size: 11px;
+    padding: 3px 8px; border-radius: 6px; }
+  .row { display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    padding: 10px 16px 14px; border-top: 1px solid var(--line); }
+  .price { font-size: 18px; font-weight: 700; }
+  .price small { font-size: 11px; font-weight: 500; color: var(--muted); margin-left: 4px; }
+  .cta { background: var(--accent); color: var(--accent-fg); border: 0; padding: 10px 16px;
+    border-radius: 10px; font: inherit; font-weight: 600; cursor: pointer; text-decoration: none;
+    display: inline-block; }
+  .cta:hover { opacity: 0.92; }
+  .footer { padding: 8px 16px 14px; font-size: 11px; color: var(--muted); text-align: right; }
+  .empty { padding: 28px 16px; color: var(--muted); text-align: center; }
+</style>
+</head>
+<body>
+<div id="root">
+  <div class="card"><div class="empty">Loading experience…</div></div>
+</div>
+<script>
+(function () {
+  "use strict";
+
+  function safeGet(obj, path) {
+    var cur = obj;
+    for (var i = 0; i < path.length; i++) {
+      if (cur == null || typeof cur !== "object") return undefined;
+      cur = cur[path[i]];
+    }
+    return cur;
+  }
+
+  function extractPayload(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    var sc = safeGet(raw, ["params", "structuredContent"]);
+    if (sc) return sc;
+    var sc2 = safeGet(raw, ["structuredContent"]);
+    if (sc2) return sc2;
+    if (raw.experience) return raw;
+    if (raw.product) return raw;
+    if (raw.title || raw.name) return raw;
+    var data = safeGet(raw, ["params", "data"]);
+    if (data) return data;
+    return raw;
+  }
+
+  function pickExperience(payload) {
+    if (!payload) return null;
+    if (payload.experience) return payload.experience;
+    if (payload.product) return payload.product;
+    if (payload.result && payload.result.experience) return payload.result.experience;
+    if (Array.isArray(payload.results) && payload.results.length) return payload.results[0];
+    if (Array.isArray(payload.experiences) && payload.experiences.length) return payload.experiences[0];
+    return payload;
+  }
+
+  function escapeHtml(s) {
+    if (s == null) return "";
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function num(v) {
+    if (v == null) return null;
+    var n = typeof v === "number" ? v : parseFloat(String(v));
+    return isFinite(n) ? n : null;
+  }
+
+  function isPopular(exp) {
+    if (exp.popular === true) return true;
+    var rating = num(exp.review_rating || exp.rating);
+    var reviews = num(exp.review_count || exp.reviews);
+    return rating != null && reviews != null && rating >= 4.5 && reviews >= 100;
+  }
+
+  function isUrgent(exp) {
+    if (exp.limited_availability === true) return true;
+    if (exp.low_availability === true) return true;
+    var b = exp._booking_urgency || exp.booking_urgency;
+    if (b && typeof b === "object") {
+      if (b.level === "high" || b.level === "limited") return true;
+      if (b.message && /limited|few|left|selling fast/i.test(String(b.message))) return true;
+    }
+    if (typeof b === "string" && /limited|few|left|selling fast/i.test(b)) return true;
+    return false;
+  }
+
+  function formatPrice(exp) {
+    var p = num(exp.minimal_price != null ? exp.minimal_price : exp.price);
+    if (p == null) return "";
+    var ccy = exp.currency || exp.currency_code || "USD";
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency: ccy,
+        maximumFractionDigits: p % 1 === 0 ? 0 : 2,
+      }).format(p);
+    } catch (e) {
+      return ccy + " " + p;
+    }
+  }
+
+  function getBookingUrl(exp) {
+    return exp.booking_url || exp.book_url || exp.url || exp.link || "";
+  }
+
+  function metaParts(exp) {
+    var parts = [];
+    if (exp.city || exp.city_name) parts.push("📍 " + escapeHtml(exp.city || exp.city_name));
+    if (exp.duration_text) parts.push("⏱ " + escapeHtml(exp.duration_text));
+    else if (exp.duration_minutes) parts.push("⏱ " + Math.round(exp.duration_minutes) + " min");
+    var rating = num(exp.review_rating || exp.rating);
+    if (rating != null) {
+      var rc = num(exp.review_count || exp.reviews);
+      parts.push("⭐ " + rating.toFixed(1) + (rc != null ? " (" + rc + ")" : ""));
+    }
+    return parts;
+  }
+
+  function tagList(exp) {
+    var tags = exp.tags || exp.categories || [];
+    if (!Array.isArray(tags)) return [];
+    return tags.slice(0, 5).map(function (t) {
+      if (typeof t === "string") return t;
+      if (t && t.name) return t.name;
+      if (t && t.label) return t.label;
+      return "";
+    }).filter(Boolean);
+  }
+
+  function emit(message) {
+    try {
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage(message, "*");
+      }
+    } catch (e) { /* swallow */ }
+  }
+
+  function onBook(url, exp) {
+    emit({
+      jsonrpc: "2.0",
+      method: "notifications/ui/event",
+      params: {
+        type: "book_click",
+        resource: "experience-card",
+        booking_url: url,
+        experience_id: exp && (exp.id || exp.product_id || exp.slug) || null,
+      },
+    });
+  }
+
+  function render(exp) {
+    var root = document.getElementById("root");
+    if (!exp || (typeof exp === "object" && !exp.title && !exp.name)) {
+      root.innerHTML = '<div class="card"><div class="empty">No experience to display.</div></div>';
+      return;
+    }
+    var title = exp.title || exp.name || "Untitled";
+    var desc = exp.short_description || exp.description || exp.summary || "";
+    var img = exp.hero_image || exp.image || exp.image_url || exp.thumbnail || "";
+    var price = formatPrice(exp);
+    var url = getBookingUrl(exp);
+    var meta = metaParts(exp);
+    var tags = tagList(exp);
+    var pop = isPopular(exp);
+    var urg = isUrgent(exp);
+
+    var html = '<div class="card">';
+    if (img) {
+      html += '<img class="hero" alt="" loading="lazy" src="' + escapeHtml(img) + '">';
+    }
+    html += '<div class="body">';
+    if (pop || urg) {
+      html += '<div class="badges">';
+      if (pop) html += '<span class="badge badge--popular">★ Popular</span>';
+      if (urg) html += '<span class="badge badge--urgent">⏳ Limited availability</span>';
+      html += '</div>';
+    }
+    html += '<h1 class="title">' + escapeHtml(title) + '</h1>';
+    if (meta.length) html += '<p class="meta">' + meta.map(function (m) { return '<span>' + m + '</span>'; }).join(" · ") + '</p>';
+    if (desc) html += '<p class="desc">' + escapeHtml(desc) + '</p>';
+    if (tags.length) {
+      html += '<div class="tags">' + tags.map(function (t) { return '<span class="tag">' + escapeHtml(t) + '</span>'; }).join("") + '</div>';
+    }
+    html += '</div>';
+    html += '<div class="row">';
+    html += '<div class="price">' + (price || "—") + (price ? '<small>from</small>' : "") + '</div>';
+    if (url) {
+      html += '<a class="cta" href="' + escapeHtml(url) + '" target="_blank" rel="noopener noreferrer" id="bookBtn">Book now</a>';
+    }
+    html += '</div>';
+    html += '<div class="footer">Powered by tickadoo®</div>';
+    html += '</div>';
+
+    root.innerHTML = html;
+
+    var btn = document.getElementById("bookBtn");
+    if (btn && url) {
+      btn.addEventListener("click", function () { onBook(url, exp); });
+    }
+  }
+
+  function handleMessage(event) {
+    var raw = event && event.data;
+    if (raw == null) return;
+    if (typeof raw === "string") {
+      try { raw = JSON.parse(raw); } catch (e) { return; }
+    }
+    var payload = extractPayload(raw);
+    var exp = pickExperience(payload);
+    if (exp && typeof exp === "object") render(exp);
+  }
+
+  window.addEventListener("message", handleMessage, false);
+
+  emit({
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: { resource: "experience-card", protocolVersion: "2025-06-18" },
+  });
+})();
+</script>
+</body>
+</html>`;
+
+const EXPERIENCE_MAP_HTML = String.raw`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>tickadoo nearby map</title>
+<link rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css"
+  integrity="sha512-h9FcoyWjHcOcmEVkxOfTLnmZFWIH0iZhZT1H2TbOq55xssQGEJHEaIm+PgoUaZbRvQTNTluNOEfb1ZRy6D3BOw=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer">
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #0f1115;
+    --muted: #5a6172;
+    --line: #e6e8ee;
+    --panel: #ffffff;
+    --pin-bg: #0f1115;
+    --pin-fg: #ffffff;
+    --pin-pop-bg: #c69b3d;
+    --pin-pop-fg: #1a1305;
+    --accent: #0f1115;
+    --accent-fg: #ffffff;
+    --tile: "light";
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1016;
+      --fg: #ecedf1;
+      --muted: #98a0b3;
+      --line: #1f2330;
+      --panel: #141823;
+      --pin-bg: #ecedf1;
+      --pin-fg: #0d1016;
+      --pin-pop-bg: #d6ad55;
+      --pin-pop-fg: #1a1305;
+      --accent: #ecedf1;
+      --accent-fg: #0d1016;
+      --tile: "dark";
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; background: var(--bg); color: var(--fg);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
+  #wrap { position: relative; width: 100%; height: 100vh; min-height: 360px; }
+  #map { position: absolute; inset: 0; }
+  .pin { display: inline-flex; align-items: center; justify-content: center;
+    background: var(--pin-bg); color: var(--pin-fg); font-weight: 700; font-size: 11px;
+    padding: 4px 8px; border-radius: 14px; white-space: nowrap;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.25); border: 1.5px solid var(--bg); }
+  .pin--popular { background: var(--pin-pop-bg); color: var(--pin-pop-fg); }
+  .panel { position: absolute; left: 12px; right: 12px; bottom: 12px; z-index: 600;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 14px;
+    padding: 12px 14px; box-shadow: 0 4px 24px rgba(0,0,0,0.18);
+    transform: translateY(120%); transition: transform 220ms ease; }
+  .panel.open { transform: translateY(0); }
+  .panel .ttl { font-weight: 600; margin: 0 0 4px; font-size: 15px; }
+  .panel .meta { color: var(--muted); font-size: 12px; margin: 0 0 8px;
+    display: flex; gap: 10px; flex-wrap: wrap; }
+  .panel .row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .panel .price { font-size: 17px; font-weight: 700; }
+  .panel .cta { background: var(--accent); color: var(--accent-fg); border: 0; padding: 9px 14px;
+    border-radius: 10px; font: inherit; font-weight: 600; cursor: pointer; text-decoration: none;
+    display: inline-block; }
+  .panel .close { position: absolute; top: 6px; right: 8px; background: transparent; border: 0;
+    color: var(--muted); font-size: 18px; line-height: 1; cursor: pointer; padding: 4px 6px; }
+  .empty { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    color: var(--muted); padding: 24px; text-align: center; z-index: 500; }
+  .footer { position: absolute; right: 8px; bottom: 6px; z-index: 700;
+    background: rgba(255,255,255,0.7); padding: 2px 6px; border-radius: 6px;
+    font-size: 10px; color: #333; }
+  @media (prefers-color-scheme: dark) {
+    .footer { background: rgba(20,24,35,0.7); color: #ccc; }
+  }
+</style>
+</head>
+<body>
+<div id="wrap">
+  <div id="map"></div>
+  <div id="empty" class="empty" style="display:none;">No mappable experiences yet.</div>
+  <div id="panel" class="panel" role="dialog" aria-hidden="true">
+    <button id="panelClose" class="close" aria-label="Close">×</button>
+    <h2 id="pnlTitle" class="ttl"></h2>
+    <p id="pnlMeta" class="meta"></p>
+    <div class="row">
+      <div id="pnlPrice" class="price"></div>
+      <a id="pnlCta" class="cta" href="#" target="_blank" rel="noopener noreferrer">Book now</a>
+    </div>
+  </div>
+  <div class="footer">Powered by tickadoo®</div>
+</div>
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js"
+  integrity="sha512-puJW3E/qXDqYp9IfhAI54BJEaWIfloJ7JWs7OeD5i6ruC9JZL1gERT1wjtwXFlh7CjE7ZJ+/vcRZRkIYIb6p4g=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"></script>
+<script>
+(function () {
+  "use strict";
+
+  var map = null;
+  var markers = [];
+
+  function safeGet(obj, path) {
+    var cur = obj;
+    for (var i = 0; i < path.length; i++) {
+      if (cur == null || typeof cur !== "object") return undefined;
+      cur = cur[path[i]];
+    }
+    return cur;
+  }
+
+  function extractPayload(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    var sc = safeGet(raw, ["params", "structuredContent"]);
+    if (sc) return sc;
+    var sc2 = safeGet(raw, ["structuredContent"]);
+    if (sc2) return sc2;
+    if (Array.isArray(raw.results)) return raw;
+    if (Array.isArray(raw.experiences)) return raw;
+    if (Array.isArray(raw)) return { results: raw };
+    var data = safeGet(raw, ["params", "data"]);
+    if (data) return data;
+    return raw;
+  }
+
+  function pickList(payload) {
+    if (!payload) return [];
+    if (Array.isArray(payload)) return payload;
+    if (Array.isArray(payload.results)) return payload.results;
+    if (Array.isArray(payload.experiences)) return payload.experiences;
+    if (Array.isArray(payload.products)) return payload.products;
+    if (Array.isArray(payload.items)) return payload.items;
+    return [];
+  }
+
+  function num(v) {
+    if (v == null) return null;
+    var n = typeof v === "number" ? v : parseFloat(String(v));
+    return isFinite(n) ? n : null;
+  }
+
+  function escapeHtml(s) {
+    if (s == null) return "";
+    return String(s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+
+  function isPopular(exp) {
+    if (exp.popular === true) return true;
+    var rating = num(exp.review_rating || exp.rating);
+    var reviews = num(exp.review_count || exp.reviews);
+    return rating != null && reviews != null && rating >= 4.5 && reviews >= 100;
+  }
+
+  function getCoords(exp) {
+    var lat = num(exp.latitude != null ? exp.latitude : (exp.lat != null ? exp.lat : safeGet(exp, ["location", "latitude"])));
+    var lng = num(exp.longitude != null ? exp.longitude : (exp.lng != null ? exp.lng : (exp.lon != null ? exp.lon : safeGet(exp, ["location", "longitude"]))));
+    if (lat == null || lng == null) return null;
+    if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return null;
+    return [lat, lng];
+  }
+
+  function priceShort(exp) {
+    var p = num(exp.minimal_price != null ? exp.minimal_price : exp.price);
+    if (p == null) return "";
+    var ccy = exp.currency || exp.currency_code || "USD";
+    var sym = ccy === "USD" ? "$" : (ccy === "EUR" ? "€" : (ccy === "GBP" ? "£" : ""));
+    var rounded = Math.round(p);
+    return sym ? sym + rounded : ccy + " " + rounded;
+  }
+
+  function priceLong(exp) {
+    var p = num(exp.minimal_price != null ? exp.minimal_price : exp.price);
+    if (p == null) return "";
+    var ccy = exp.currency || exp.currency_code || "USD";
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: "currency", currency: ccy,
+        maximumFractionDigits: p % 1 === 0 ? 0 : 2,
+      }).format(p);
+    } catch (e) {
+      return ccy + " " + p;
+    }
+  }
+
+  function getBookingUrl(exp) {
+    return exp.booking_url || exp.book_url || exp.url || exp.link || "";
+  }
+
+  function panelMeta(exp) {
+    var parts = [];
+    var rating = num(exp.review_rating || exp.rating);
+    if (rating != null) {
+      var rc = num(exp.review_count || exp.reviews);
+      parts.push("⭐ " + rating.toFixed(1) + (rc != null ? " (" + rc + ")" : ""));
+    }
+    if (exp.distance_text) parts.push("📍 " + escapeHtml(exp.distance_text));
+    else if (exp.distance_km != null) parts.push("📍 " + Number(exp.distance_km).toFixed(1) + " km");
+    if (exp.duration_text) parts.push("⏱ " + escapeHtml(exp.duration_text));
+    return parts.join(" · ");
+  }
+
+  function emit(message) {
+    try {
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage(message, "*");
+      }
+    } catch (e) { /* swallow */ }
+  }
+
+  function onBook(url, exp) {
+    emit({
+      jsonrpc: "2.0",
+      method: "notifications/ui/event",
+      params: {
+        type: "book_click",
+        resource: "experience-map",
+        booking_url: url,
+        experience_id: exp && (exp.id || exp.product_id || exp.slug) || null,
+      },
+    });
+  }
+
+  function showPanel(exp) {
+    var p = document.getElementById("panel");
+    document.getElementById("pnlTitle").textContent = exp.title || exp.name || "Experience";
+    document.getElementById("pnlMeta").innerHTML = panelMeta(exp);
+    document.getElementById("pnlPrice").textContent = priceLong(exp);
+    var cta = document.getElementById("pnlCta");
+    var url = getBookingUrl(exp);
+    if (url) {
+      cta.style.display = "inline-block";
+      cta.setAttribute("href", url);
+      cta.onclick = function () { onBook(url, exp); };
+    } else {
+      cta.style.display = "none";
+    }
+    p.classList.add("open");
+    p.setAttribute("aria-hidden", "false");
+  }
+
+  function hidePanel() {
+    var p = document.getElementById("panel");
+    p.classList.remove("open");
+    p.setAttribute("aria-hidden", "true");
+  }
+
+  function ensureMap() {
+    if (map) return map;
+    if (typeof L === "undefined") return null;
+    map = L.map("map", { zoomControl: true, attributionControl: false }).setView([51.5, -0.12], 12);
+    var dark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var url = dark
+      ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+      : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+    L.tileLayer(url, { maxZoom: 19, subdomains: "abcd" }).addTo(map);
+    return map;
+  }
+
+  function renderList(list) {
+    var m = ensureMap();
+    if (!m) return;
+
+    markers.forEach(function (mk) { try { m.removeLayer(mk); } catch (e) {} });
+    markers = [];
+    hidePanel();
+
+    var withCoords = list
+      .map(function (e) { return { exp: e, coords: getCoords(e || {}) }; })
+      .filter(function (x) { return x.coords; });
+
+    var emptyEl = document.getElementById("empty");
+    if (!withCoords.length) {
+      emptyEl.style.display = "flex";
+      return;
+    }
+    emptyEl.style.display = "none";
+
+    var bounds = L.latLngBounds([]);
+    withCoords.forEach(function (item) {
+      var exp = item.exp;
+      var coords = item.coords;
+      var pop = isPopular(exp);
+      var label = priceShort(exp) || (exp.title ? "•" : "•");
+      var icon = L.divIcon({
+        className: "",
+        html: '<div class="pin' + (pop ? ' pin--popular' : '') + '">' + escapeHtml(label) + '</div>',
+        iconSize: null,
+        iconAnchor: [20, 12],
+      });
+      var marker = L.marker(coords, { icon: icon }).addTo(m);
+      marker.on("click", function () { showPanel(exp); });
+      markers.push(marker);
+      bounds.extend(coords);
+    });
+    if (markers.length === 1) {
+      m.setView(markers[0].getLatLng(), 14);
+    } else {
+      m.fitBounds(bounds.pad(0.15));
+    }
+  }
+
+  function handleMessage(event) {
+    var raw = event && event.data;
+    if (raw == null) return;
+    if (typeof raw === "string") {
+      try { raw = JSON.parse(raw); } catch (e) { return; }
+    }
+    var payload = extractPayload(raw);
+    var list = pickList(payload);
+    renderList(list);
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    ensureMap();
+    var btn = document.getElementById("panelClose");
+    if (btn) btn.addEventListener("click", hidePanel);
+  });
+
+  window.addEventListener("message", handleMessage, false);
+
+  emit({
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: { resource: "experience-map", protocolVersion: "2025-06-18" },
+  });
+})();
+</script>
+</body>
+</html>`;
+
+const UI_RESOURCES: readonly UiResourceSpec[] = [
+  {
+    name: "experience-card",
+    uri: EXPERIENCE_CARD_URI,
+    description:
+      "Inline booking card for a single tickadoo experience. Rendered by MCP Apps-capable clients when get_experience_details returns.",
+    html: EXPERIENCE_CARD_HTML,
+  },
+  {
+    name: "experience-map",
+    uri: EXPERIENCE_MAP_URI,
+    description:
+      "Interactive map with price-pin markers for a list of nearby tickadoo experiences. Rendered by MCP Apps-capable clients when find_nearby_experiences returns.",
+    html: EXPERIENCE_MAP_HTML,
+  },
+];
+
+/**
+ * Register both tickadoo UI resources on the given MCP server. Safe to call
+ * once per server instance (call site is `createTickadooServer` just before
+ * `return server;`).
+ */
+export function registerTickadooUiResources(server: McpServer): void {
+  for (const resource of UI_RESOURCES) {
+    server.resource(
+      resource.name,
+      resource.uri,
+      {
+        description: resource.description,
+        mimeType: "text/html",
+      },
+      async () => ({
+        contents: [
+          {
+            uri: resource.uri,
+            text: resource.html,
+            mimeType: "text/html",
+          },
+        ],
+      }),
+    );
+  }
+}
+
+/** Exposed for tests. */
+export const TICKADOO_UI_RESOURCES: readonly UiResourceSpec[] = UI_RESOURCES;

--- a/src/shared/ui-resources.ts
+++ b/src/shared/ui-resources.ts
@@ -26,23 +26,46 @@ export const EXPERIENCE_MAP_URI = "ui://tickadoo/experience-map.html";
  * resources. The dual key shape (`ui.resourceUri` + `openai/outputTemplate`)
  * lets one declaration light up Claude/Goose/VS Code (MCP Apps spec) and
  * ChatGPT Apps simultaneously, with neither client breaking on the other's
- * key.
+ * key. Optional `invoking`/`invoked` hints are ChatGPT-only loading state
+ * strings; conforming MCP-Apps clients ignore them safely.
  */
-export function uiMeta(uri: string): {
+export function uiMeta(
+  uri: string,
+  hints?: { invoking?: string; invoked?: string },
+): {
   ui: { resourceUri: string };
   "openai/outputTemplate": string;
+  "openai/toolInvocation/invoking"?: string;
+  "openai/toolInvocation/invoked"?: string;
 } {
-  return {
+  const meta: {
+    ui: { resourceUri: string };
+    "openai/outputTemplate": string;
+    "openai/toolInvocation/invoking"?: string;
+    "openai/toolInvocation/invoked"?: string;
+  } = {
     ui: { resourceUri: uri },
     "openai/outputTemplate": uri,
   };
+  if (hints?.invoking) meta["openai/toolInvocation/invoking"] = hints.invoking;
+  if (hints?.invoked) meta["openai/toolInvocation/invoked"] = hints.invoked;
+  return meta;
 }
+
+/**
+ * MCP Apps standard MIME type. Hosts (Claude, ChatGPT, Goose, VS Code)
+ * only enable the MCP Apps bridge — sandbox iframe + ui/* postMessage
+ * channel — when this exact MIME is returned. Plain `text/html` is
+ * treated as a generic resource and will NOT render inline.
+ */
+export const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
 
 interface UiResourceSpec {
   readonly name: string;
   readonly uri: string;
   readonly description: string;
   readonly html: string;
+  readonly resourceMeta?: Record<string, unknown>;
 }
 
 const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
@@ -213,7 +236,19 @@ const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
   }
 
   function getBookingUrl(exp) {
-    return exp.booking_url || exp.book_url || exp.url || exp.link || "";
+    var raw = exp.booking_url || exp.book_url || exp.url || exp.link || "";
+    if (!raw) return "";
+    try {
+      var u = new URL(raw, "https://www.tickadoo.com");
+      if (!u.searchParams.has("utm_source")) {
+        u.searchParams.set("utm_source", "mcp");
+        u.searchParams.set("utm_medium", "mcp-app");
+        u.searchParams.set("utm_campaign", "experience-card");
+      }
+      return u.toString();
+    } catch (e) {
+      return raw;
+    }
   }
 
   function metaParts(exp) {
@@ -524,7 +559,19 @@ const EXPERIENCE_MAP_HTML = String.raw`<!doctype html>
   }
 
   function getBookingUrl(exp) {
-    return exp.booking_url || exp.book_url || exp.url || exp.link || "";
+    var raw = exp.booking_url || exp.book_url || exp.url || exp.link || "";
+    if (!raw) return "";
+    try {
+      var u = new URL(raw, "https://www.tickadoo.com");
+      if (!u.searchParams.has("utm_source")) {
+        u.searchParams.set("utm_source", "mcp");
+        u.searchParams.set("utm_medium", "mcp-app");
+        u.searchParams.set("utm_campaign", "experience-map");
+      }
+      return u.toString();
+    } catch (e) {
+      return raw;
+    }
   }
 
   function panelMeta(exp) {
@@ -676,6 +723,12 @@ const UI_RESOURCES: readonly UiResourceSpec[] = [
     description:
       "Inline booking card for a single tickadoo experience. Rendered by MCP Apps-capable clients when get_experience_details returns.",
     html: EXPERIENCE_CARD_HTML,
+    resourceMeta: {
+      ui: {
+        // Card already has its own rounded-border styling; suppress host chrome.
+        prefersBorder: false,
+      },
+    },
   },
   {
     name: "experience-map",
@@ -683,6 +736,23 @@ const UI_RESOURCES: readonly UiResourceSpec[] = [
     description:
       "Interactive map with price-pin markers for a list of nearby tickadoo experiences. Rendered by MCP Apps-capable clients when find_nearby_experiences returns.",
     html: EXPERIENCE_MAP_HTML,
+    resourceMeta: {
+      ui: {
+        prefersBorder: true,
+        // Map iframe fetches Leaflet from cdnjs and basemap tiles from CARTO.
+        // Hosts with strict CSP (Claude, ChatGPT) block anything not listed here.
+        csp: {
+          resourceDomains: [
+            "https://cdnjs.cloudflare.com",
+            "https://a.basemaps.cartocdn.com",
+            "https://b.basemaps.cartocdn.com",
+            "https://c.basemaps.cartocdn.com",
+            "https://d.basemaps.cartocdn.com",
+          ],
+          connectDomains: [],
+        },
+      },
+    },
   },
 ];
 
@@ -698,14 +768,15 @@ export function registerTickadooUiResources(server: McpServer): void {
       resource.uri,
       {
         description: resource.description,
-        mimeType: "text/html",
+        mimeType: MCP_APP_MIME_TYPE,
       },
       async () => ({
         contents: [
           {
             uri: resource.uri,
             text: resource.html,
-            mimeType: "text/html",
+            mimeType: MCP_APP_MIME_TYPE,
+            ...(resource.resourceMeta ? { _meta: resource.resourceMeta } : {}),
           },
         ],
       }),

--- a/tests/ui-resources.test.ts
+++ b/tests/ui-resources.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   EXPERIENCE_CARD_URI,
   EXPERIENCE_MAP_URI,
+  MCP_APP_MIME_TYPE,
   TICKADOO_UI_RESOURCES,
   uiMeta,
 } from "../src/shared/ui-resources.js";
@@ -10,6 +11,10 @@ describe("ui-resources", () => {
   it("exports the two expected URIs", () => {
     expect(EXPERIENCE_CARD_URI).toBe("ui://tickadoo/experience-card.html");
     expect(EXPERIENCE_MAP_URI).toBe("ui://tickadoo/experience-map.html");
+  });
+
+  it("uses the MCP Apps standard mime type", () => {
+    expect(MCP_APP_MIME_TYPE).toBe("text/html;profile=mcp-app");
   });
 
   it("exposes both resources via TICKADOO_UI_RESOURCES", () => {
@@ -25,24 +30,46 @@ describe("ui-resources", () => {
     const meta = uiMeta(EXPERIENCE_CARD_URI);
     expect(meta.ui.resourceUri).toBe(EXPERIENCE_CARD_URI);
     expect(meta["openai/outputTemplate"]).toBe(EXPERIENCE_CARD_URI);
+    expect(meta["openai/toolInvocation/invoking"]).toBeUndefined();
+    expect(meta["openai/toolInvocation/invoked"]).toBeUndefined();
   });
 
-  it("experience-card HTML carries the required markers", () => {
+  it("uiMeta supports optional ChatGPT invocation hints", () => {
+    const meta = uiMeta(EXPERIENCE_MAP_URI, {
+      invoking: "Searching…",
+      invoked: "Done",
+    });
+    expect(meta["openai/toolInvocation/invoking"]).toBe("Searching…");
+    expect(meta["openai/toolInvocation/invoked"]).toBe("Done");
+  });
+
+  it("experience-card HTML carries the required markers and UTM attribution", () => {
     const card = TICKADOO_UI_RESOURCES.find(r => r.name === "experience-card");
     expect(card).toBeDefined();
     expect(card!.html).toContain("badge--popular");
     expect(card!.html).toContain("tickadoo\u00ae");
+    expect(card!.html).toContain("utm_source");
+    expect(card!.html).toContain("experience-card");
   });
 
-  it("experience-map HTML carries the required markers", () => {
+  it("experience-map HTML carries the required markers and UTM attribution", () => {
     const map = TICKADOO_UI_RESOURCES.find(r => r.name === "experience-map");
     expect(map).toBeDefined();
     expect(map!.html).toContain("cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4");
     expect(map!.html).toContain("pin--popular");
     expect(map!.html).toContain("tickadoo\u00ae");
+    expect(map!.html).toContain("utm_source");
+    expect(map!.html).toContain("experience-map");
   });
 
-  it("each resource declares the html mimetype and a description", () => {
+  it("experience-map resource declares CSP allowlist for cdnjs and CARTO", () => {
+    const map = TICKADOO_UI_RESOURCES.find(r => r.name === "experience-map");
+    const ui = (map!.resourceMeta as { ui?: { csp?: { resourceDomains?: string[] } } } | undefined)?.ui;
+    expect(ui?.csp?.resourceDomains).toContain("https://cdnjs.cloudflare.com");
+    expect(ui?.csp?.resourceDomains?.some(d => d.includes("basemaps.cartocdn.com"))).toBe(true);
+  });
+
+  it("each resource declares an html doctype and a description", () => {
     for (const r of TICKADOO_UI_RESOURCES) {
       expect(typeof r.description).toBe("string");
       expect(r.description.length).toBeGreaterThan(0);

--- a/tests/ui-resources.test.ts
+++ b/tests/ui-resources.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  EXPERIENCE_CARD_URI,
+  EXPERIENCE_MAP_URI,
+  TICKADOO_UI_RESOURCES,
+  uiMeta,
+} from "../src/shared/ui-resources.js";
+
+describe("ui-resources", () => {
+  it("exports the two expected URIs", () => {
+    expect(EXPERIENCE_CARD_URI).toBe("ui://tickadoo/experience-card.html");
+    expect(EXPERIENCE_MAP_URI).toBe("ui://tickadoo/experience-map.html");
+  });
+
+  it("exposes both resources via TICKADOO_UI_RESOURCES", () => {
+    expect(TICKADOO_UI_RESOURCES).toHaveLength(2);
+    const byName = Object.fromEntries(
+      TICKADOO_UI_RESOURCES.map(r => [r.name, r]),
+    );
+    expect(byName["experience-card"].uri).toBe(EXPERIENCE_CARD_URI);
+    expect(byName["experience-map"].uri).toBe(EXPERIENCE_MAP_URI);
+  });
+
+  it("uiMeta produces both ui.resourceUri and openai/outputTemplate keys", () => {
+    const meta = uiMeta(EXPERIENCE_CARD_URI);
+    expect(meta.ui.resourceUri).toBe(EXPERIENCE_CARD_URI);
+    expect(meta["openai/outputTemplate"]).toBe(EXPERIENCE_CARD_URI);
+  });
+
+  it("experience-card HTML carries the required markers", () => {
+    const card = TICKADOO_UI_RESOURCES.find(r => r.name === "experience-card");
+    expect(card).toBeDefined();
+    expect(card!.html).toContain("badge--popular");
+    expect(card!.html).toContain("tickadoo\u00ae");
+  });
+
+  it("experience-map HTML carries the required markers", () => {
+    const map = TICKADOO_UI_RESOURCES.find(r => r.name === "experience-map");
+    expect(map).toBeDefined();
+    expect(map!.html).toContain("cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4");
+    expect(map!.html).toContain("pin--popular");
+    expect(map!.html).toContain("tickadoo\u00ae");
+  });
+
+  it("each resource declares the html mimetype and a description", () => {
+    for (const r of TICKADOO_UI_RESOURCES) {
+      expect(typeof r.description).toBe("string");
+      expect(r.description.length).toBeGreaterThan(0);
+      expect(r.html.startsWith("<!doctype html>")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds MCP Apps support to the tickadoo MCP server (GRO-229). Two UI resources are now registered alongside the existing tools:

- `experience-card` (`ui://tickadoo/experience-card.html`) — wired to `get_experience_details`. Renders a single bookable experience as an inline card: hero image, Popular badge (rating ≥ 4.5 + reviews ≥ 100), Limited-availability badge when an urgency signal is present, title, city/duration/rating meta, 3-line clamp description, tag chips, currency-formatted price (`Intl.NumberFormat`), Book CTA opening `booking_url` in `target=_blank`, and a `tickadoo®` footer. Light + dark via `prefers-color-scheme`.
- `experience-map` (`ui://tickadoo/experience-map.html`) — wired to `find_nearby_experiences`. Renders a Leaflet 1.9.4 map (loaded from cdnjs with SRI integrity hashes inside the iframe only) with CARTO light/dark tile layers, price-pin `divIcon` markers (gold tint when popular), and a bottom panel that opens on marker click with title, rating/distance meta, formatted price, and a Book CTA. Empty-state handler when experiences lack coordinates.

Both resources are wired via `_meta.ui.resourceUri` (the MCP Apps spec key) plus `openai/outputTemplate` (the ChatGPT Apps fallback key). Conforming clients (Claude, ChatGPT Apps, Goose, VS Code) render inline; non-conforming clients ignore `_meta.ui` and fall back to the existing text + structured content responses, so this change is fully additive.

## Approach

HTML is kept inline as `String.raw` template literals in `src/shared/ui-resources.ts`, not as separate `.html` files. This keeps the module runtime-portable across Node, Cloudflare Workers, and Vercel Edge without any bundler plugin or fs access at request time, which matches how `dist/index.js` is shipped today (single-file esbuild bundle).

Iframe scripts use defensive payload extraction — they accept `{method:"tools/toolResult", params:{structuredContent}}` plus `.experience` / `.product` / bare-object fallbacks — and they emit an `initialize` notification on load and a `notifications/ui/event` with `{type:"book_click"}` upstream when the Book CTA is clicked.

## Server.ts edits (6, surgical)

1. Added the `ui-resources` import after the existing `import { z } from "zod";`.
2. Wrapped `find_nearby_experiences` registration as `const nearbyTool = server.tool(...)`.
3. Inserted `nearbyTool.update({ _meta: uiMeta(EXPERIENCE_MAP_URI) });` immediately before `list_cities` is registered.
4. Wrapped `get_experience_details` registration as `const detailsTool = server.tool(...)`.
5. Inserted `detailsTool.update({ _meta: uiMeta(EXPERIENCE_CARD_URI) });` immediately before `compare_experiences` is registered.
6. Inserted `registerTickadooUiResources(server);` immediately before the existing `return server;` at the end of `createTickadooServer`.

## Tests

New suite `tests/ui-resources.test.ts` (6 cases, all passing) asserts the URI exports, the `TICKADOO_UI_RESOURCES` registration shape, the `uiMeta()` dual-key shape, and the presence of the required HTML markers (`badge--popular`, `pin--popular`, `cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4`, literal `tickadoo®`).

## Build verification

- `npm run build`: clean esbuild bundle at 359.0kb (was 358.7kb pre-change).
- `npx tsc --noEmit`: only the 3 pre-existing unrelated errors at `tests/integration.test.ts` L1210-1211 and `tests/last-minute.test.ts` L16. No new errors introduced by this branch.
- `npx vitest run tests/ui-resources.test.ts`: 6 / 6 passing in 6 ms.

## Dependencies

Zero new npm dependencies. Leaflet 1.9.4 is loaded from cdnjs with SRI integrity hashes only inside the experience-map iframe at render time — it never enters the server bundle.

## Version

`1.4.3` → `1.5.0`. CHANGELOG entry prepended.

Claude-Chat: tickadooMCP6