### PR TITLE
feat(telemetry): agent calls + attribution loop (GRO-230)

### DIFF
--- a/admin/telemetry.html
+++ b/admin/telemetry.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>tickadoo telemetry</title>
+<style>
+  body{font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;max-width:1200px;margin:20px auto;padding:0 20px;color:#111}
+  h1{font-size:20px;margin:0 0 20px}
+  h2{font-size:15px;margin:28px 0 8px;color:#555;font-weight:600}
+  table{border-collapse:collapse;width:100%;font-size:13px}
+  th,td{border-bottom:1px solid #eee;padding:6px 10px;text-align:left}
+  th{background:#f6f6f7;font-weight:600}
+  .num{text-align:right;font-variant-numeric:tabular-nums}
+  .muted{color:#888}
+</style></head><body>
+<h1>tickadoo agent telemetry <span class="muted">last 24h</span></h1>
+<h2>Volume</h2>
+<table id="volume"><thead><tr><th>metric</th><th class="num">value</th></tr></thead><tbody></tbody></table>
+<h2>Calls by tool (24h)</h2>
+<table id="byTool"><thead><tr><th>tool</th><th class="num">calls</th><th class="num">errors</th><th class="num">avg latency</th><th class="num">conversion</th></tr></thead><tbody></tbody></table>
+<h2>Calls by host (24h)</h2>
+<table id="byHost"><thead><tr><th>host</th><th class="num">calls</th></tr></thead><tbody></tbody></table>
+<h2>Top cities (7d)</h2>
+<table id="byCity"><thead><tr><th>city</th><th class="num">calls</th></tr></thead><tbody></tbody></table>
+<h2>Top products shown (7d)</h2>
+<table id="topProducts"><thead><tr><th>slug</th><th class="num">shown</th></tr></thead><tbody></tbody></table>
+<script>
+fetch('/admin/telemetry.json').then(function (response) { return response.json(); }).then(function (data) {
+  var addRow = function (selector, cells) {
+    var tr = document.createElement('tr');
+    cells.forEach(function (cell, index) {
+      var td = document.createElement('td');
+      td.textContent = String(cell);
+      if (index > 0) td.className = 'num';
+      tr.appendChild(td);
+    });
+    document.querySelector(selector + ' tbody').appendChild(tr);
+  };
+  addRow('#volume', ['total calls 24h', data.volume.total24h]);
+  addRow('#volume', ['bookings 24h', data.volume.bookings24h]);
+  addRow('#volume', ['conversion 24h', (data.volume.conversion * 100).toFixed(2) + '%']);
+  data.byTool.forEach(function (row) {
+    addRow('#byTool', [row.tool_name, row.calls, row.errors, row.avg_latency_ms + 'ms', (row.conversion * 100).toFixed(1) + '%']);
+  });
+  data.byHost.forEach(function (row) { addRow('#byHost', [row.host_hint, row.calls]); });
+  data.byCity.forEach(function (row) { addRow('#byCity', [row.city || '(unknown)', row.calls]); });
+  data.topProducts.forEach(function (row) { addRow('#topProducts', [row.slug, row.shown]); });
+}).catch(function (error) {
+  document.body.insertAdjacentHTML('beforeend', '<p class="muted">Failed to load telemetry: ' + String(error) + '</p>');
+});
+</script></body></html>

--- a/api/admin-telemetry-page.ts
+++ b/api/admin-telemetry-page.ts
@@ -1,0 +1,32 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { SERVER_VERSION } from "../src/shared/config.js";
+import { TELEMETRY_DASHBOARD_HTML } from "../src/shared/telemetry-dashboard.js";
+import { writeMethodNotAllowed, writeReadonlyOptionsResponse } from "./_shared.js";
+
+// TODO: Gate this route behind shared admin auth once the repo has one.
+export default function handler(req: IncomingMessage, res: ServerResponse): void {
+  if (req.method === "OPTIONS") {
+    writeReadonlyOptionsResponse(res);
+    return;
+  }
+
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    writeMethodNotAllowed(res);
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "*");
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-MCP-Server-Version", SERVER_VERSION);
+
+  if (req.method === "HEAD") {
+    res.end();
+    return;
+  }
+
+  res.end(TELEMETRY_DASHBOARD_HTML);
+}

--- a/api/admin-telemetry.ts
+++ b/api/admin-telemetry.ts
@@ -1,0 +1,40 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { SERVER_VERSION } from "../src/shared/config.js";
+import { createTelemetrySql } from "../src/shared/telemetry.js";
+import { fetchTelemetryDashboard } from "../src/shared/telemetry-dashboard.js";
+import {
+  writeJson,
+  writeMethodNotAllowed,
+  writeReadonlyOptionsResponse,
+} from "./_shared.js";
+
+// TODO: Gate this route behind shared admin auth once the repo has one.
+export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method === "OPTIONS") {
+    writeReadonlyOptionsResponse(res);
+    return;
+  }
+
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    writeMethodNotAllowed(res);
+    return;
+  }
+
+  const sql = createTelemetrySql(process.env.NEON_URL);
+  if (!sql) {
+    writeJson(req, res, { error: "NEON_URL is not configured" }, { cacheControl: "no-store", statusCode: 500 });
+    return;
+  }
+
+  try {
+    writeJson(req, res, await fetchTelemetryDashboard(sql), { cacheControl: "no-store" });
+  } catch (error) {
+    res.setHeader("X-MCP-Server-Version", SERVER_VERSION);
+    writeJson(
+      req,
+      res,
+      { error: error instanceof Error ? error.message : String(error) },
+      { cacheControl: "no-store", statusCode: 500 },
+    );
+  }
+}

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { SERVER_VERSION } from "../src/shared/config.js";
 import { buildHealthPayload, CONTENT_SECURITY_POLICY, RESPONSE_CACHE_CONTROL, writeJson } from "./_shared.js";
 import { createTickadooServer } from "../src/shared/server.js";
+import { createTelemetrySql } from "../src/shared/telemetry.js";
 
 type BodyCapableRequest = IncomingMessage & { body?: unknown };
 
@@ -51,7 +52,9 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     return;
   }
 
-  const server = createTickadooServer();
+  const server = createTickadooServer({
+    telemetrySql: createTelemetrySql(process.env.NEON_URL),
+  });
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,

--- a/db/migrations/001_agent_telemetry.sql
+++ b/db/migrations/001_agent_telemetry.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_calls (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  tool_name TEXT NOT NULL,
+  input_args JSONB NOT NULL,
+  result_count INT,
+  top_product_ids TEXT[] DEFAULT '{}',
+  request_id TEXT,
+  session_id TEXT,
+  host_hint TEXT NOT NULL DEFAULT 'unknown',
+  origin_host TEXT,
+  latency_ms INT,
+  is_error BOOLEAN DEFAULT false,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_calls_created_at ON agent_calls (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_calls_tool_time ON agent_calls (tool_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_calls_host_time ON agent_calls (host_hint, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_calls_top_ids ON agent_calls USING GIN (top_product_ids);
+
+CREATE TABLE IF NOT EXISTS agent_call_bookings (
+  agent_call_id UUID NOT NULL REFERENCES agent_calls(id) ON DELETE CASCADE,
+  booking_id TEXT NOT NULL,
+  booked_at TIMESTAMPTZ NOT NULL,
+  gross_amount NUMERIC(10,2),
+  currency CHAR(3),
+  supplier TEXT,
+  product_slug TEXT,
+  PRIMARY KEY (agent_call_id, booking_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_acb_booked_at ON agent_call_bookings (booked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_acb_supplier ON agent_call_bookings (supplier, booked_at DESC);
+
+COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@neondatabase/serverless": "^1.1.0",
         "hono": "^4.7.0",
         "zod": "^3.23.8"
       },
@@ -1215,6 +1216,15 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@oxc-project/types": {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "zod": "^3.23.8",
-    "hono": "^4.7.0"
+    "@neondatabase/serverless": "^1.1.0",
+    "hono": "^4.7.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22.19.15",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { TICKADOO_LOG_LEVEL } from "./shared/config.js";
 import { createTickadooServer } from "./shared/server.js";
+import { createTelemetrySql } from "./shared/telemetry.js";
 
 // Emit plugin hint for Claude Code auto-discovery
 // When running inside Claude Code, this prompts users to install the tickadoo plugin
@@ -14,6 +15,7 @@ if (process.env.CLAUDECODE) {
 
 async function main(): Promise<void> {
   const server = createTickadooServer({
+    telemetrySql: createTelemetrySql(process.env.NEON_URL),
     logWriter: message => {
       process.stderr.write(`${message}\n`);
     },

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -9,6 +9,12 @@ import {
 } from "./ui-resources.js";
 import { neonQuery } from "./neon.js";
 import {
+  extractTopProductIds,
+  recordAgentCall,
+  stampAgentCallId,
+  type SqlClient,
+} from "./telemetry.js";
+import {
   buildAvailabilityCheckPayload,
   calculateAvailabilityWindowDays,
   CHECK_AVAILABILITY_NEXT_STEP_HINT,
@@ -201,6 +207,7 @@ type LogWriter = (message: string) => void;
 type ToolLogSummary = Record<string, boolean | number | string | undefined>;
 type CreateTickadooServerOptions = {
   logWriter?: LogWriter;
+  telemetrySql?: SqlClient | null;
 };
 const SEARCH_SORT_OPTION_SET = new Set<string>(SEARCH_SORT_OPTIONS);
 const SEARCH_MOOD_OPTION_SET = new Set<string>(SEARCH_MOOD_OPTIONS);
@@ -1138,6 +1145,16 @@ type LoggedToolExecution = {
   summary?: ToolLogSummary;
 };
 
+type ToolRequestInfo = {
+  headers: Record<string, string | string[] | undefined>;
+  url?: URL;
+};
+
+type ToolExtra = {
+  requestInfo?: ToolRequestInfo;
+  sessionId?: string;
+};
+
 function defaultLogWriter(message: string) {
   console.log(message);
 }
@@ -1203,14 +1220,14 @@ function writeInfoLog(
 function withToolLogging<TArgs>(
   toolName: string,
   logWriter: LogWriter,
-  handler: (args: TArgs) => Promise<LoggedToolExecution>,
-): (args: TArgs) => Promise<ToolResponse> {
-  return async (args: TArgs) => {
+  handler: (args: TArgs, extra: ToolExtra) => Promise<LoggedToolExecution>,
+): (args: TArgs, extra: ToolExtra) => Promise<ToolResponse> {
+  return async (args: TArgs, extra: ToolExtra) => {
     const startedAt = Date.now();
     writeDebugLog(logWriter, toolName, "request", args);
 
     try {
-      const execution = await handler(args);
+      const execution = await handler(args, extra);
       writeInfoLog(
         logWriter,
         toolName,
@@ -1227,6 +1244,63 @@ function withToolLogging<TArgs>(
       throw error;
     }
   };
+}
+
+function extractResponseErrorMessage(response: ToolResponse): string | undefined {
+  if (response.isError !== true) {
+    return undefined;
+  }
+
+  const textPart = response.content.find((item): item is { type: "text"; text: string } =>
+    item.type === "text",
+  );
+  const text = textPart?.text?.trim();
+  if (!text) {
+    return undefined;
+  }
+
+  return text.startsWith("Error: ") ? text.slice("Error: ".length) : text;
+}
+
+function getStructuredContentObject(response: ToolResponse): Record<string, unknown> {
+  return response.structuredContent && typeof response.structuredContent === "object"
+    ? response.structuredContent as Record<string, unknown>
+    : {};
+}
+
+async function recordUiToolTelemetry(
+  telemetrySql: SqlClient | null | undefined,
+  toolName: string,
+  args: unknown,
+  extra: ToolExtra | undefined,
+  execution: LoggedToolExecution,
+  startedAt: number,
+): Promise<void> {
+  if (!telemetrySql || !extra?.requestInfo) {
+    return;
+  }
+
+  const structuredContent = getStructuredContentObject(execution.response);
+  const agentCallId = await recordAgentCall(
+    {
+      sql: telemetrySql,
+      requestInfo: extra.requestInfo,
+      startedAt,
+      sessionId: extra.sessionId,
+    },
+    {
+      toolName,
+      inputArgs: args,
+      resultCount: execution.resultCount,
+      topProductIds: extractTopProductIds(structuredContent),
+      isError: execution.response.isError === true,
+      errorMessage: extractResponseErrorMessage(execution.response),
+    },
+  );
+
+  if (agentCallId && execution.response.isError !== true) {
+    stampAgentCallId(structuredContent, agentCallId);
+  }
 }
 
 function formatValue(value: unknown): string {
@@ -2793,6 +2867,7 @@ async function executeSearchTool(request: SearchExecutionArgs): Promise<LoggedTo
 }
 export function createTickadooServer(options: CreateTickadooServerOptions = {}): McpServer {
   const logWriter = options.logWriter ?? defaultLogWriter;
+  const telemetrySql = options.telemetrySql ?? null;
   const server = new McpServer({
     name: SERVER_NAME,
     version: SERVER_VERSION,
@@ -3456,106 +3531,114 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
       format: z.enum(RESPONSE_FORMATS).optional().default("text").describe("Response format: text (default) or json"),
     },
     READ_ONLY_TOOL_ANNOTATIONS,
-    withToolLogging("find_nearby_experiences", logWriter, async args => {
-      const validated = validateNearbyArgs(args);
-      if (!validated.ok) {
-        return {
-          response: validated.error,
-          resultCount: 0,
-          summary: {
-            lat: typeof args.latitude === "number" ? args.latitude : undefined,
-            lng: typeof args.longitude === "number" ? args.longitude : undefined,
-            date_from: typeof args.dateFrom === "string" ? args.dateFrom.trim() || undefined : undefined,
-            date_to: typeof args.dateTo === "string" ? args.dateTo.trim() || undefined : undefined,
-            format: typeof args.format === "string" ? args.format : undefined,
-          },
-        };
-      }
-
-      const { latitude, longitude, radiusKm, dateFrom, dateTo, language, format } = validated.data;
-      const tagsArg = typeof args.tags === "string" ? args.tags : undefined;
-
-      try {
-        let products = await getProductsByLocation(latitude, longitude, radiusKm, language, { dateFrom, dateTo });
-        if (tagsArg) {
-          products = filterProductsByTags(products, tagsArg);
+    withToolLogging("find_nearby_experiences", logWriter, async (args, extra) => {
+      const startedAt = Date.now();
+      const execution = await (async (): Promise<LoggedToolExecution> => {
+        const validated = validateNearbyArgs(args);
+        if (!validated.ok) {
+          return {
+            response: validated.error,
+            resultCount: 0,
+            summary: {
+              lat: typeof args.latitude === "number" ? args.latitude : undefined,
+              lng: typeof args.longitude === "number" ? args.longitude : undefined,
+              date_from: typeof args.dateFrom === "string" ? args.dateFrom.trim() || undefined : undefined,
+              date_to: typeof args.dateTo === "string" ? args.dateTo.trim() || undefined : undefined,
+              format: typeof args.format === "string" ? args.format : undefined,
+            },
+          };
         }
-        if (!products.length) {
-          const suggestedRadiusKm = Math.min(radiusKm * 2, MAX_RADIUS_KM);
-          const [nearestCity] = await getNearbyCitySuggestions(latitude, longitude, language);
+
+        const { latitude, longitude, radiusKm, dateFrom, dateTo, language, format } = validated.data;
+        const tagsArg = typeof args.tags === "string" ? args.tags : undefined;
+
+        try {
+          let products = await getProductsByLocation(latitude, longitude, radiusKm, language, { dateFrom, dateTo });
+          if (tagsArg) {
+            products = filterProductsByTags(products, tagsArg);
+          }
+          if (!products.length) {
+            const suggestedRadiusKm = Math.min(radiusKm * 2, MAX_RADIUS_KM);
+            const [nearestCity] = await getNearbyCitySuggestions(latitude, longitude, language);
+            return {
+              response: createFormattedResponse(
+                format,
+                formatNearbyEmptyRecovery(
+                  radiusKm,
+                  suggestedRadiusKm,
+                  nearestCity ? { name: nearestCity.city.name } : undefined,
+                ),
+                nearbyEmptyRecoveryJson(
+                  latitude,
+                  longitude,
+                  radiusKm,
+                  suggestedRadiusKm,
+                  nearestCity ? { name: nearestCity.city.name } : undefined,
+                ),
+              ),
+              resultCount: 0,
+              summary: { lat: latitude, lng: longitude, radius_km: radiusKm, date_from: dateFrom, date_to: dateTo, format },
+            };
+          }
+
+          const enrichedProducts = await getMcpEnrichedProducts();
+          let filteredProducts = mergeEnrichedProducts(products, enrichedProducts);
+          filteredProducts = filterProductsByAudience(filteredProducts, args.audience as string | undefined);
+          filteredProducts = filterProductsBySetting(filteredProducts, args.setting as string | undefined);
+          filteredProducts = filterProductsByAccessibility(filteredProducts, args.wheelchair_accessible as boolean | undefined);
+          filteredProducts = filterProductsByPhysicalLevel(filteredProducts, args.physical_level as string | undefined);
+          filteredProducts = filterProductsByDuration(filteredProducts, args.min_duration as number | undefined, args.max_duration as number | undefined);
+          filteredProducts = filterProductsByLanguage(filteredProducts, args.available_language as string | undefined);
+          filteredProducts = filterProductsByRating(filteredProducts, args.min_rating as number | undefined);
+          filteredProducts = filterProductsByFreeCancellation(filteredProducts, args.free_cancellation as boolean | undefined);
+          const nearbySort = (typeof args.sort === "string" ? args.sort : "relevance") as SearchSort;
+          const nearbyMax = Math.min(Math.max(typeof args.max_results === "number" ? args.max_results : DEFAULT_SEARCH_RESULT_LIMIT, 1), 50);
+          const rankedProducts = sortProductsForSearch(filteredProducts, nearbySort);
+          const topProducts = rankedProducts.slice(0, nearbyMax);
+          let nearbyCitySlug = "nearby";
+          if (topProducts.length > 0) {
+            const cities = await getCities(language);
+            const firstCityId = topProducts[0].cityId;
+            const matchedCity = cities.find(ct => ct.id === firstCityId);
+            if (matchedCity?.slug) {
+              nearbyCitySlug = matchedCity.slug;
+            }
+          }
+
           return {
             response: createFormattedResponse(
               format,
-              formatNearbyEmptyRecovery(
-                radiusKm,
-                suggestedRadiusKm,
-                nearestCity ? { name: nearestCity.city.name } : undefined,
+              appendNextStepHint(
+                `${buildShownResultsLabel(topProducts.length, products.length, "nearby")}\n\n${topProducts.map(product => formatProduct(product, product.slug, language)).join("\n\n")}${formatAvailableFiltersHint(topProducts as any)}`,
+                NEARBY_NEXT_STEP_HINT,
               ),
-              nearbyEmptyRecoveryJson(
-                latitude,
-                longitude,
-                radiusKm,
-                suggestedRadiusKm,
-                nearestCity ? { name: nearestCity.city.name } : undefined,
-              ),
+              { ...nearbyJsonPayload(latitude, longitude, radiusKm, products.length, topProducts, language, { dateFrom, dateTo }), _available_filters: buildAvailableFilters(topProducts as any), _related_searches: buildRelatedSearches(nearbyCitySlug, topProducts as any), _conversation_starters: buildConversationStarters(topProducts as any, "nearby"), _best_picks: buildBestPicks(topProducts as any), _price_tiers: buildPriceTiers(topProducts as any), _group_summary: buildGroupSummary(topProducts as any) },
+              {
+                structuredContent: {
+                  latitude,
+                  longitude,
+                  radiusKm,
+                  ...(dateFrom ? { dateFrom } : {}),
+                  ...(dateTo ? { dateTo } : {}),
+                  totalExperiences: products.length,
+                  experiences: topProducts.map(product => productStructuredData(product, product.slug, language)),
+                },
+              },
             ),
+            resultCount: topProducts.length,
+            summary: { lat: latitude, lng: longitude, radius_km: radiusKm, date_from: dateFrom, date_to: dateTo, format },
+          };
+        } catch (error) {
+          return {
+            response: createFormattedErrorResponse(format, getErrorMessage(error)),
             resultCount: 0,
             summary: { lat: latitude, lng: longitude, radius_km: radiusKm, date_from: dateFrom, date_to: dateTo, format },
           };
         }
+      })();
 
-        const enrichedProducts = await getMcpEnrichedProducts();
-        let filteredProducts = mergeEnrichedProducts(products, enrichedProducts);
-        filteredProducts = filterProductsByAudience(filteredProducts, args.audience as string | undefined);
-        filteredProducts = filterProductsBySetting(filteredProducts, args.setting as string | undefined);
-        filteredProducts = filterProductsByAccessibility(filteredProducts, args.wheelchair_accessible as boolean | undefined);
-        filteredProducts = filterProductsByPhysicalLevel(filteredProducts, args.physical_level as string | undefined);
-        filteredProducts = filterProductsByDuration(filteredProducts, args.min_duration as number | undefined, args.max_duration as number | undefined);
-        filteredProducts = filterProductsByLanguage(filteredProducts, args.available_language as string | undefined);
-        filteredProducts = filterProductsByRating(filteredProducts, args.min_rating as number | undefined);
-        filteredProducts = filterProductsByFreeCancellation(filteredProducts, args.free_cancellation as boolean | undefined);
-        const nearbySort = (typeof args.sort === "string" ? args.sort : "relevance") as SearchSort;
-        const nearbyMax = Math.min(Math.max(typeof args.max_results === "number" ? args.max_results : DEFAULT_SEARCH_RESULT_LIMIT, 1), 50);
-        const rankedProducts = sortProductsForSearch(filteredProducts, nearbySort);
-        const topProducts = rankedProducts.slice(0, nearbyMax);
-        // Resolve city slug for _related_searches
-        let nearbyCitySlug = "nearby";
-        if (topProducts.length > 0) {
-          const cities = await getCities(language);
-          const firstCityId = topProducts[0].cityId;
-          const matchedCity = cities.find(ct => ct.id === firstCityId);
-          if (matchedCity?.slug) nearbyCitySlug = matchedCity.slug;
-        }
-        return {
-          response: createFormattedResponse(
-            format,
-            appendNextStepHint(
-              `${buildShownResultsLabel(topProducts.length, products.length, "nearby")}\n\n${topProducts.map(product => formatProduct(product, product.slug, language)).join("\n\n")}${formatAvailableFiltersHint(topProducts as any)}`,
-              NEARBY_NEXT_STEP_HINT,
-            ),
-            { ...nearbyJsonPayload(latitude, longitude, radiusKm, products.length, topProducts, language, { dateFrom, dateTo }), _available_filters: buildAvailableFilters(topProducts as any), _related_searches: buildRelatedSearches(nearbyCitySlug, topProducts as any), _conversation_starters: buildConversationStarters(topProducts as any, "nearby"), _best_picks: buildBestPicks(topProducts as any), _price_tiers: buildPriceTiers(topProducts as any), _group_summary: buildGroupSummary(topProducts as any) },
-            {
-              structuredContent: {
-                latitude,
-                longitude,
-                radiusKm,
-                ...(dateFrom ? { dateFrom } : {}),
-                ...(dateTo ? { dateTo } : {}),
-                totalExperiences: products.length,
-                experiences: topProducts.map(product => productStructuredData(product, product.slug, language)),
-              },
-            },
-          ),
-          resultCount: topProducts.length,
-          summary: { lat: latitude, lng: longitude, radius_km: radiusKm, date_from: dateFrom, date_to: dateTo, format },
-        };
-      } catch (error) {
-        return {
-          response: createFormattedErrorResponse(format, getErrorMessage(error)),
-          resultCount: 0,
-          summary: { lat: latitude, lng: longitude, radius_km: radiusKm, date_from: dateFrom, date_to: dateTo, format },
-        };
-      }
+      await recordUiToolTelemetry(telemetrySql, "find_nearby_experiences", args, extra, execution, startedAt);
+      return execution;
     }),
   );
 
@@ -3955,80 +4038,98 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
       format: z.enum(RESPONSE_FORMATS).optional().default("text").describe("Response format: text (default) or json"),
     },
     READ_ONLY_TOOL_ANNOTATIONS,
-    withToolLogging("get_experience_details", logWriter, async args => {
-      const validated = validateExperienceDetailsArgs(args);
-      if (!validated.ok) {
-        return {
-          response: validated.error,
-          resultCount: 0,
-          summary: {
-            slug: typeof args.slug === "string" ? args.slug.trim() || "(empty)" : undefined,
-            format: typeof args.format === "string" ? args.format : undefined,
-          },
-        };
-      }
-
-      const {
-        slug,
-        provider,
-        providerId,
-        days,
-        language,
-        format,
-      } = validated.data;
-
-      try {
-        let resolved: ResolvedProduct | undefined;
-        let providerName = provider;
-        let detailsProviderId = providerId;
-
-        if (slug) {
-          resolved = await resolveProductBySlug(slug, language);
-          providerName = resolved.product.provider;
-          detailsProviderId = resolved.product.providerId;
+    withToolLogging("get_experience_details", logWriter, async (args, extra) => {
+      const startedAt = Date.now();
+      const execution = await (async (): Promise<LoggedToolExecution> => {
+        const validated = validateExperienceDetailsArgs(args);
+        if (!validated.ok) {
+          return {
+            response: validated.error,
+            resultCount: 0,
+            summary: {
+              slug: typeof args.slug === "string" ? args.slug.trim() || "(empty)" : undefined,
+              format: typeof args.format === "string" ? args.format : undefined,
+            },
+          };
         }
 
-        const [details, enrichedProducts] = await Promise.all([
-          getExperienceDetails(providerName!, detailsProviderId!, days),
-          resolved?.product.slug ? getMcpEnrichedProducts() : Promise.resolve(new Map<string, McpProduct>()),
-        ]);
-        const enrichedDetails = mergeEnrichedDetails(details, resolved?.product.slug, enrichedProducts);
-        const bookingPath = resolved?.bookingPath;
-        return {
-          response: createFormattedResponse(
-            format,
-            appendNextStepHint([
-              resolved ? `🎭 ${resolved.product.title}` : "",
-              formatExperienceDetails(days, enrichedDetails),
-              resolved ? `   🔗 ${buildBookingUrl(resolved.bookingPath, language)}` : "",
-            ].filter(Boolean).join("\n"), resolved ? DETAILS_NEXT_STEP_HINT : undefined),
-            experienceDetailsJsonPayload(days, enrichedDetails, {
-              title: resolved?.product.title,
-              slug: resolved?.product.slug,
-              bookingPath,
-              language,
-            }),
-            {
-              structuredContent: {
-                source: "tickadoo",
-                slug: resolved?.product.slug,
-                tickadooProductId: resolved?.product.id,
-                bookingUrl: resolved ? buildBookingUrl(resolved.bookingPath, language) : undefined,
-                days,
-                details: enrichedDetails,
+        const {
+          slug,
+          provider,
+          providerId,
+          days,
+          language,
+          format,
+        } = validated.data;
+
+        try {
+          let resolved: ResolvedProduct | undefined;
+          let providerName = provider;
+          let detailsProviderId = providerId;
+
+          if (slug) {
+            resolved = await resolveProductBySlug(slug, language);
+            providerName = resolved.product.provider;
+            detailsProviderId = resolved.product.providerId;
+          }
+
+          const [details, enrichedProducts] = await Promise.all([
+            getExperienceDetails(providerName!, detailsProviderId!, days),
+            resolved?.product.slug ? getMcpEnrichedProducts() : Promise.resolve(new Map<string, McpProduct>()),
+          ]);
+          const enrichedDetails = mergeEnrichedDetails(details, resolved?.product.slug, enrichedProducts);
+          const bookingPath = resolved?.bookingPath;
+          const bookingUrl = resolved ? buildBookingUrl(resolved.bookingPath, language) : undefined;
+          const detailJson = experienceDetailsJsonPayload(days, enrichedDetails, {
+            title: resolved?.product.title,
+            slug: resolved?.product.slug,
+            bookingPath,
+            language,
+          });
+          const primaryVariant = enrichedDetails.mcpProduct?.variants?.[0];
+
+          return {
+            response: createFormattedResponse(
+              format,
+              appendNextStepHint([
+                resolved ? `🎭 ${resolved.product.title}` : "",
+                formatExperienceDetails(days, enrichedDetails),
+                resolved ? `   🔗 ${bookingUrl}` : "",
+              ].filter(Boolean).join("\n"), resolved ? DETAILS_NEXT_STEP_HINT : undefined),
+              detailJson,
+              {
+                structuredContent: {
+                  source: "tickadoo",
+                  title: resolved?.product.title,
+                  slug: resolved?.product.slug,
+                  tickadooProductId: resolved?.product.id,
+                  bookingUrl,
+                  booking_url: bookingUrl,
+                  imageUrl: enrichedDetails.desktopFeatureImageUrl ?? undefined,
+                  image_url: enrichedDetails.desktopFeatureImageUrl ?? undefined,
+                  duration_text: formatDuration(primaryVariant?.duration ?? null) ?? undefined,
+                  review_rating: enrichedDetails.mcpProduct?.reviewRating ?? null,
+                  review_count: enrichedDetails.mcpProduct?.reviewCount ?? null,
+                  tags: enrichedDetails.mcpProduct?.tags ?? [],
+                  days,
+                  details: enrichedDetails,
+                },
               },
-            },
-          ),
-          resultCount: 1,
-          summary: { slug: slug ?? `${providerName}:${detailsProviderId}`, format },
-        };
-      } catch (error) {
-        return {
-          response: createFormattedErrorResponse(format, getErrorMessage(error)),
-          resultCount: 0,
-          summary: { slug: slug ?? `${provider ?? ""}:${providerId ?? ""}`, format },
-        };
-      }
+            ),
+            resultCount: 1,
+            summary: { slug: slug ?? `${providerName}:${detailsProviderId}`, format },
+          };
+        } catch (error) {
+          return {
+            response: createFormattedErrorResponse(format, getErrorMessage(error)),
+            resultCount: 0,
+            summary: { slug: slug ?? `${provider ?? ""}:${providerId ?? ""}`, format },
+          };
+        }
+      })();
+
+      await recordUiToolTelemetry(telemetrySql, "get_experience_details", args, extra, execution, startedAt);
+      return execution;
     }),
   );
 
@@ -4125,144 +4226,150 @@ export function createTickadooServer(options: CreateTickadooServerOptions = {}):
       max_results: z.number().int().min(1).max(10).default(6),
     },
     READ_ONLY_TOOL_ANNOTATIONS,
-    withToolLogging("get_related_experiences", logWriter, async args => {
-      const edgeTypePreference: Record<"pair" | "after" | "nearby" | "similar", string[]> = {
-        pair: ["co_booked", "tag_overlap", "spatial"],
-        after: ["co_booked", "spatial"],
-        nearby: ["spatial"],
-        similar: ["similar", "tag_overlap"],
-      };
-      const productId = typeof args.product_id === "string" ? args.product_id.trim() : "";
-      const context = (args.context ?? "pair") as "pair" | "after" | "nearby" | "similar";
-      const maxResults = typeof args.max_results === "number" ? args.max_results : 6;
-
-      if (!productId) {
-        return {
-          response: createErrorResponse("product_id is required."),
-          resultCount: 0,
-          summary: {
-            context,
-            max_results: maxResults,
-          },
+    withToolLogging("get_related_experiences", logWriter, async (args, extra) => {
+      const startedAt = Date.now();
+      const execution = await (async (): Promise<LoggedToolExecution> => {
+        const edgeTypePreference: Record<"pair" | "after" | "nearby" | "similar", string[]> = {
+          pair: ["co_booked", "tag_overlap", "spatial"],
+          after: ["co_booked", "spatial"],
+          nearby: ["spatial"],
+          similar: ["similar", "tag_overlap"],
         };
-      }
+        const productId = typeof args.product_id === "string" ? args.product_id.trim() : "";
+        const context = (args.context ?? "pair") as "pair" | "after" | "nearby" | "similar";
+        const maxResults = typeof args.max_results === "number" ? args.max_results : 6;
 
-      try {
-        const edgeTypes = edgeTypePreference[context];
-        const edges = await neonQuery<Array<{ target_id: string; edge_type: string; strength: number; metadata: unknown }>[number]>(
-          `SELECT target_id, edge_type, strength, metadata
-           FROM product_edges
-           WHERE source_id = $1
-             AND edge_type = ANY($2::text[])
-           ORDER BY strength DESC
-           LIMIT $3`,
-          [productId, edgeTypes, maxResults * 3],
-        );
-
-        const byTarget = new Map<string, { edge_type: string; strength: number; metadata: unknown }>();
-        for (const edge of edges) {
-          const prev = byTarget.get(edge.target_id);
-          if (!prev || Number(edge.strength) > prev.strength) {
-            byTarget.set(edge.target_id, {
-              edge_type: edge.edge_type,
-              strength: Number(edge.strength),
-              metadata: edge.metadata,
-            });
-          }
+        if (!productId) {
+          return {
+            response: createErrorResponse("product_id is required."),
+            resultCount: 0,
+            summary: {
+              context,
+              max_results: maxResults,
+            },
+          };
         }
 
-        const topTargets = Array.from(byTarget.entries())
-          .sort((a, b) => b[1].strength - a[1].strength)
-          .slice(0, maxResults);
+        try {
+          const edgeTypes = edgeTypePreference[context];
+          const edges = await neonQuery<Array<{ target_id: string; edge_type: string; strength: number; metadata: unknown }>[number]>(
+            `SELECT target_id, edge_type, strength, metadata
+             FROM product_edges
+             WHERE source_id = $1
+               AND edge_type = ANY($2::text[])
+             ORDER BY strength DESC
+             LIMIT $3`,
+            [productId, edgeTypes, maxResults * 3],
+          );
 
-        const targetSlugs = topTargets.map(([slug]) => slug);
-        const products = targetSlugs.length > 0
-          ? await neonQuery<Array<{
-            slug: string;
-            title: string;
-            description: string | null;
-            image_url: string | null;
-            booking_url: string | null;
-            price: number | null;
-            currency: string | null;
-            rating: number | null;
-            review_count: number | null;
-            city_slug: string;
-            latitude: number | null;
-            longitude: number | null;
-          }>[number]>(
-            `SELECT DISTINCT ON (slug)
-               slug,
-               name AS title,
-               description,
-               COALESCE(image_url, desktop_image_url, vertical_image_url) AS image_url,
-               checkout_url AS booking_url,
-               price_from AS price,
-               currency_code AS currency,
-               rating,
-               review_count,
-               city_slug,
-               latitude,
-               longitude
-             FROM products
-             WHERE slug = ANY($1::text[])
-             ORDER BY slug, rating DESC NULLS LAST, review_count DESC NULLS LAST, updated_at DESC NULLS LAST, created_at DESC NULLS LAST`,
-            [targetSlugs],
-          )
-          : [];
-
-        const bySlug = new Map(products.map(product => [product.slug, product]));
-        const results = topTargets
-          .map(([slug, edge]) => {
-            const product = bySlug.get(slug);
-            if (!product) {
-              return null;
+          const byTarget = new Map<string, { edge_type: string; strength: number; metadata: unknown }>();
+          for (const edge of edges) {
+            const prev = byTarget.get(edge.target_id);
+            if (!prev || Number(edge.strength) > prev.strength) {
+              byTarget.set(edge.target_id, {
+                edge_type: edge.edge_type,
+                strength: Number(edge.strength),
+                metadata: edge.metadata,
+              });
             }
+          }
 
-            return {
-              ...product,
-              booking_url: product.booking_url || buildBookingUrl(`${product.city_slug}/${product.slug}`),
-              price: product.price == null ? null : Number(product.price),
-              rating: product.rating == null ? null : Number(product.rating),
-              review_count: product.review_count == null ? null : Number(product.review_count),
-              location: product.latitude != null && product.longitude != null
-                ? { latitude: Number(product.latitude), longitude: Number(product.longitude) }
-                : null,
-              edge_type: edge.edge_type,
-              edge_strength: edge.strength,
-              edge_metadata: edge.metadata,
-            };
-          })
-          .filter((value): value is NonNullable<typeof value> => value !== null);
+          const topTargets = Array.from(byTarget.entries())
+            .sort((a, b) => b[1].strength - a[1].strength)
+            .slice(0, maxResults);
 
-        const payload = {
-          source_id: productId,
-          context,
-          results,
-          total: results.length,
-        };
+          const targetSlugs = topTargets.map(([slug]) => slug);
+          const products = targetSlugs.length > 0
+            ? await neonQuery<Array<{
+              slug: string;
+              title: string;
+              description: string | null;
+              image_url: string | null;
+              booking_url: string | null;
+              price: number | null;
+              currency: string | null;
+              rating: number | null;
+              review_count: number | null;
+              city_slug: string;
+              latitude: number | null;
+              longitude: number | null;
+            }>[number]>(
+              `SELECT DISTINCT ON (slug)
+                 slug,
+                 name AS title,
+                 description,
+                 COALESCE(image_url, desktop_image_url, vertical_image_url) AS image_url,
+                 checkout_url AS booking_url,
+                 price_from AS price,
+                 currency_code AS currency,
+                 rating,
+                 review_count,
+                 city_slug,
+                 latitude,
+                 longitude
+               FROM products
+               WHERE slug = ANY($1::text[])
+               ORDER BY slug, rating DESC NULLS LAST, review_count DESC NULLS LAST, updated_at DESC NULLS LAST, created_at DESC NULLS LAST`,
+              [targetSlugs],
+            )
+            : [];
 
-        return {
-          response: createTextResponse(formatRelatedAsText(payload), { structuredContent: payload }),
-          resultCount: results.length,
-          summary: {
-            product_id: productId,
+          const bySlug = new Map(products.map(product => [product.slug, product]));
+          const results = topTargets
+            .map(([slug, edge]) => {
+              const product = bySlug.get(slug);
+              if (!product) {
+                return null;
+              }
+
+              return {
+                ...product,
+                booking_url: product.booking_url || buildBookingUrl(`${product.city_slug}/${product.slug}`),
+                price: product.price == null ? null : Number(product.price),
+                rating: product.rating == null ? null : Number(product.rating),
+                review_count: product.review_count == null ? null : Number(product.review_count),
+                location: product.latitude != null && product.longitude != null
+                  ? { latitude: Number(product.latitude), longitude: Number(product.longitude) }
+                  : null,
+                edge_type: edge.edge_type,
+                edge_strength: edge.strength,
+                edge_metadata: edge.metadata,
+              };
+            })
+            .filter((value): value is NonNullable<typeof value> => value !== null);
+
+          const payload = {
+            source_id: productId,
             context,
-            max_results: maxResults,
-            returned: results.length,
-          },
-        };
-      } catch (error) {
-        return {
-          response: createErrorResponse(getErrorMessage(error)),
-          resultCount: 0,
-          summary: {
-            product_id: productId,
-            context,
-            max_results: maxResults,
-          },
-        };
-      }
+            results,
+            total: results.length,
+          };
+
+          return {
+            response: createTextResponse(formatRelatedAsText(payload), { structuredContent: payload }),
+            resultCount: results.length,
+            summary: {
+              product_id: productId,
+              context,
+              max_results: maxResults,
+              returned: results.length,
+            },
+          };
+        } catch (error) {
+          return {
+            response: createErrorResponse(getErrorMessage(error)),
+            resultCount: 0,
+            summary: {
+              product_id: productId,
+              context,
+              max_results: maxResults,
+            },
+          };
+        }
+      })();
+
+      await recordUiToolTelemetry(telemetrySql, "get_related_experiences", args, extra, execution, startedAt);
+      return execution;
     }),
   );
 

--- a/src/shared/telemetry-dashboard.ts
+++ b/src/shared/telemetry-dashboard.ts
@@ -1,0 +1,142 @@
+import type { SqlClient } from "./telemetry.js";
+
+export interface TelemetryDashboardVolume {
+  total24h: number;
+  bookings24h: number;
+  conversion: number;
+}
+
+export interface TelemetryDashboardToolRow {
+  tool_name: string;
+  calls: number;
+  errors: number;
+  avg_latency_ms: number;
+  conversion: number;
+}
+
+export interface TelemetryDashboardHostRow {
+  host_hint: string;
+  calls: number;
+}
+
+export interface TelemetryDashboardCityRow {
+  city: string | null;
+  calls: number;
+}
+
+export interface TelemetryDashboardProductRow {
+  slug: string;
+  shown: number;
+}
+
+export interface TelemetryDashboardPayload {
+  volume: TelemetryDashboardVolume;
+  byTool: TelemetryDashboardToolRow[];
+  byHost: TelemetryDashboardHostRow[];
+  byCity: TelemetryDashboardCityRow[];
+  topProducts: TelemetryDashboardProductRow[];
+}
+
+export const TELEMETRY_DASHBOARD_HTML = String.raw`<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>tickadoo telemetry</title>
+<style>
+  body{font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;max-width:1200px;margin:20px auto;padding:0 20px;color:#111}
+  h1{font-size:20px;margin:0 0 20px}
+  h2{font-size:15px;margin:28px 0 8px;color:#555;font-weight:600}
+  table{border-collapse:collapse;width:100%;font-size:13px}
+  th,td{border-bottom:1px solid #eee;padding:6px 10px;text-align:left}
+  th{background:#f6f6f7;font-weight:600}
+  .num{text-align:right;font-variant-numeric:tabular-nums}
+  .muted{color:#888}
+</style></head><body>
+<h1>tickadoo agent telemetry <span class="muted">last 24h</span></h1>
+<h2>Volume</h2>
+<table id="volume"><thead><tr><th>metric</th><th class="num">value</th></tr></thead><tbody></tbody></table>
+<h2>Calls by tool (24h)</h2>
+<table id="byTool"><thead><tr><th>tool</th><th class="num">calls</th><th class="num">errors</th><th class="num">avg latency</th><th class="num">conversion</th></tr></thead><tbody></tbody></table>
+<h2>Calls by host (24h)</h2>
+<table id="byHost"><thead><tr><th>host</th><th class="num">calls</th></tr></thead><tbody></tbody></table>
+<h2>Top cities (7d)</h2>
+<table id="byCity"><thead><tr><th>city</th><th class="num">calls</th></tr></thead><tbody></tbody></table>
+<h2>Top products shown (7d)</h2>
+<table id="topProducts"><thead><tr><th>slug</th><th class="num">shown</th></tr></thead><tbody></tbody></table>
+<script>
+fetch('/admin/telemetry.json').then(function (response) { return response.json(); }).then(function (data) {
+  var addRow = function (selector, cells) {
+    var tr = document.createElement('tr');
+    cells.forEach(function (cell, index) {
+      var td = document.createElement('td');
+      td.textContent = String(cell);
+      if (index > 0) td.className = 'num';
+      tr.appendChild(td);
+    });
+    document.querySelector(selector + ' tbody').appendChild(tr);
+  };
+  addRow('#volume', ['total calls 24h', data.volume.total24h]);
+  addRow('#volume', ['bookings 24h', data.volume.bookings24h]);
+  addRow('#volume', ['conversion 24h', (data.volume.conversion * 100).toFixed(2) + '%']);
+  data.byTool.forEach(function (row) {
+    addRow('#byTool', [row.tool_name, row.calls, row.errors, row.avg_latency_ms + 'ms', (row.conversion * 100).toFixed(1) + '%']);
+  });
+  data.byHost.forEach(function (row) { addRow('#byHost', [row.host_hint, row.calls]); });
+  data.byCity.forEach(function (row) { addRow('#byCity', [row.city || '(unknown)', row.calls]); });
+  data.topProducts.forEach(function (row) { addRow('#topProducts', [row.slug, row.shown]); });
+}).catch(function (error) {
+  document.body.insertAdjacentHTML('beforeend', '<p class="muted">Failed to load telemetry: ' + String(error) + '</p>');
+});
+</script></body></html>`;
+
+export async function fetchTelemetryDashboard(sql: SqlClient): Promise<TelemetryDashboardPayload> {
+  const volumeRows = await sql<{ total24h: number; bookings24h: number }>`
+    SELECT
+      (SELECT count(*)::int FROM agent_calls WHERE created_at > now() - interval '24 hours') AS total24h,
+      (SELECT count(*)::int FROM agent_call_bookings WHERE booked_at > now() - interval '24 hours') AS bookings24h
+  `;
+  const volumeBase = volumeRows[0] ?? { total24h: 0, bookings24h: 0 };
+  const volume = {
+    ...volumeBase,
+    conversion: volumeBase.total24h > 0 ? volumeBase.bookings24h / volumeBase.total24h : 0,
+  };
+
+  const byTool = await sql<TelemetryDashboardToolRow>`
+    SELECT
+      ac.tool_name,
+      count(*)::int AS calls,
+      count(*) FILTER (WHERE ac.is_error)::int AS errors,
+      coalesce(round(avg(ac.latency_ms))::int, 0) AS avg_latency_ms,
+      coalesce((count(DISTINCT acb.booking_id)::real / NULLIF(count(*), 0)::real), 0) AS conversion
+    FROM agent_calls ac
+    LEFT JOIN agent_call_bookings acb ON acb.agent_call_id = ac.id
+    WHERE ac.created_at > now() - interval '24 hours'
+    GROUP BY ac.tool_name
+    ORDER BY calls DESC
+  `;
+
+  const byHost = await sql<TelemetryDashboardHostRow>`
+    SELECT host_hint, count(*)::int AS calls
+    FROM agent_calls
+    WHERE created_at > now() - interval '24 hours'
+    GROUP BY host_hint
+    ORDER BY calls DESC
+  `;
+
+  const byCity = await sql<TelemetryDashboardCityRow>`
+    SELECT input_args->>'city' AS city, count(*)::int AS calls
+    FROM agent_calls
+    WHERE created_at > now() - interval '7 days' AND input_args ? 'city'
+    GROUP BY city
+    ORDER BY calls DESC
+    LIMIT 20
+  `;
+
+  const topProducts = await sql<TelemetryDashboardProductRow>`
+    SELECT unnest(ac.top_product_ids) AS slug, count(*)::int AS shown
+    FROM agent_calls ac
+    WHERE ac.created_at > now() - interval '7 days'
+    GROUP BY slug
+    ORDER BY shown DESC
+    LIMIT 20
+  `;
+
+  return { volume, byTool, byHost, byCity, topProducts };
+}

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -1,0 +1,201 @@
+import { neon } from "@neondatabase/serverless";
+
+// Agent call telemetry and attribution helpers.
+
+type HeaderValue = string | string[] | undefined;
+
+export type SqlClient = <TRow = Record<string, unknown>>(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+) => Promise<TRow[]>;
+
+export interface TelemetryRequestInfo {
+  headers: Record<string, HeaderValue>;
+  url?: URL;
+}
+
+export interface TelemetryContext {
+  sql: SqlClient;
+  requestInfo: TelemetryRequestInfo;
+  startedAt: number;
+  sessionId?: string;
+}
+
+export interface TelemetryRecord {
+  toolName: string;
+  inputArgs: unknown;
+  resultCount?: number;
+  topProductIds?: string[];
+  isError?: boolean;
+  errorMessage?: string;
+}
+
+const HOST_HINT_PATTERNS: Array<[RegExp, string]> = [
+  [/claude/i, "claude"],
+  [/anthropic/i, "claude"],
+  [/chatgpt|openai/i, "chatgpt"],
+  [/goose/i, "goose"],
+  [/vscode|visualstudio/i, "vscode"],
+  [/postman/i, "postman"],
+  [/curl/i, "curl"],
+];
+
+export function createTelemetrySql(connectionString?: string | null): SqlClient | null {
+  const trimmed = connectionString?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return neon(trimmed) as unknown as SqlClient;
+}
+
+function getHeaderValue(headers: Record<string, HeaderValue>, headerName: string): string | undefined {
+  const wanted = headerName.toLowerCase();
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== wanted) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      return value[0];
+    }
+
+    return value;
+  }
+
+  return undefined;
+}
+
+export function inferHostHint(userAgent: string, origin: string): string {
+  const combined = `${userAgent} ${origin}`;
+  for (const [pattern, hint] of HOST_HINT_PATTERNS) {
+    if (pattern.test(combined)) {
+      return hint;
+    }
+  }
+
+  return "unknown";
+}
+
+/**
+ * Writes a single agent_calls row and returns the id.
+ * Wrapped in try/catch so telemetry failures never degrade a user-facing response.
+ */
+export async function recordAgentCall(
+  ctx: TelemetryContext,
+  record: TelemetryRecord,
+): Promise<string | null> {
+  try {
+    const headers = ctx.requestInfo.headers;
+    const userAgent = getHeaderValue(headers, "user-agent") ?? "";
+    const origin = getHeaderValue(headers, "origin") ?? "";
+    const refererOrigin = (() => {
+      try {
+        const referer = getHeaderValue(headers, "referer");
+        return referer ? new URL(referer).origin : "";
+      } catch {
+        return "";
+      }
+    })();
+    const hostHint = inferHostHint(userAgent, origin || refererOrigin);
+    const latencyMs = Math.max(0, Date.now() - ctx.startedAt);
+
+    const rows = await ctx.sql<{ id: string }>`
+      INSERT INTO agent_calls (
+        tool_name, input_args, result_count, top_product_ids,
+        request_id, session_id, host_hint, origin_host,
+        latency_ms, is_error, error_message
+      ) VALUES (
+        ${record.toolName},
+        ${JSON.stringify(record.inputArgs ?? {})}::jsonb,
+        ${record.resultCount ?? null},
+        ${record.topProductIds ?? []},
+        ${getHeaderValue(headers, "x-request-id") ?? null},
+        ${ctx.sessionId ?? getHeaderValue(headers, "mcp-session-id") ?? null},
+        ${hostHint},
+        ${origin || refererOrigin || ctx.requestInfo.url?.origin || null},
+        ${latencyMs},
+        ${record.isError ?? false},
+        ${record.errorMessage ?? null}
+      )
+      RETURNING id
+    `;
+
+    return rows[0]?.id ?? null;
+  } catch (error) {
+    console.warn("telemetry write failed", error);
+    return null;
+  }
+}
+
+/**
+ * Extracts top product ids from a tool response's structuredContent.
+ * Handles nearby payloads (results[] or experiences[]), single experience
+ * payloads, and details payloads where slug sits at the top level.
+ */
+export function extractTopProductIds(structuredContent: unknown, n = 3): string[] {
+  if (!structuredContent || typeof structuredContent !== "object") {
+    return [];
+  }
+
+  const sc = structuredContent as Record<string, unknown>;
+  const topLevelId = [sc.slug, sc.id, sc.product_id]
+    .find((value): value is string => typeof value === "string" && value.length > 0);
+  const candidates = [
+    Array.isArray(sc.results) ? sc.results : null,
+    Array.isArray(sc.experiences) ? sc.experiences : null,
+    sc.experience ? [sc.experience] : null,
+    sc.product ? [sc.product] : null,
+  ];
+  const list = (candidates.find(candidate => candidate !== null) ?? []) as Array<Record<string, unknown>>;
+  const ids = [
+    ...(topLevelId ? [topLevelId] : []),
+    ...list.map(item =>
+      (typeof item.slug === "string" && item.slug)
+      || (typeof item.id === "string" && item.id)
+      || (typeof item.product_id === "string" && item.product_id)
+      || "",
+    ),
+  ].filter(Boolean);
+
+  return [...new Set(ids)].slice(0, n);
+}
+
+/**
+ * Stamps agent_call_id onto a tool response's structuredContent so the widget
+ * can emit utm_content back to the booking webhook for attribution.
+ * Mutates both top-level _meta and per-item _meta so card and map widgets
+ * both see it.
+ */
+export function stampAgentCallId(structuredContent: Record<string, unknown>, agentCallId: string): void {
+  const currentMeta = (structuredContent._meta as Record<string, unknown>) || {};
+  structuredContent._meta = { ...currentMeta, agent_call_id: agentCallId };
+
+  const lists = [
+    Array.isArray(structuredContent.results) ? structuredContent.results : null,
+    Array.isArray(structuredContent.experiences) ? structuredContent.experiences : null,
+  ];
+
+  for (const list of lists) {
+    if (!list) {
+      continue;
+    }
+
+    for (const item of list as Array<Record<string, unknown>>) {
+      const meta = (item._meta as Record<string, unknown>) || {};
+      item._meta = { ...meta, agent_call_id: agentCallId };
+    }
+  }
+
+  for (const key of ["experience", "product"]) {
+    const value = structuredContent[key];
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+
+    const item = value as Record<string, unknown>;
+    const meta = (item._meta as Record<string, unknown>) || {};
+    item._meta = { ...meta, agent_call_id: agentCallId };
+  }
+}

--- a/src/shared/ui-resources.ts
+++ b/src/shared/ui-resources.ts
@@ -204,8 +204,8 @@ const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
 
   function isPopular(exp) {
     if (exp.popular === true) return true;
-    var rating = num(exp.review_rating || exp.rating);
-    var reviews = num(exp.review_count || exp.reviews);
+    var rating = num(exp.review_rating || exp.reviewRating || exp.rating);
+    var reviews = num(exp.review_count || exp.reviewCount || exp.reviews);
     return rating != null && reviews != null && rating >= 4.5 && reviews >= 100;
   }
 
@@ -222,9 +222,12 @@ const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
   }
 
   function formatPrice(exp) {
-    var p = num(exp.minimal_price != null ? exp.minimal_price : exp.price);
+    var rawPrice = exp.minimal_price != null
+      ? exp.minimal_price
+      : (exp.priceAmount != null ? exp.priceAmount : (exp.price && typeof exp.price === "object" ? exp.price.amount : exp.price));
+    var p = num(rawPrice);
     if (p == null) return "";
-    var ccy = exp.currency || exp.currency_code || "USD";
+    var ccy = exp.currency || exp.currency_code || exp.priceCurrency || (exp.price && exp.price.currency) || "USD";
     try {
       return new Intl.NumberFormat(undefined, {
         style: "currency",
@@ -237,7 +240,7 @@ const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
   }
 
   function getBookingUrl(exp) {
-    var raw = exp.booking_url || exp.book_url || exp.url || exp.link || "";
+    var raw = exp.booking_url || exp.bookingUrl || exp.book_url || exp.url || exp.link || "";
     if (!raw) return "";
     try {
       var u = new URL(raw, "https://www.tickadoo.com");
@@ -245,6 +248,10 @@ const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
         u.searchParams.set("utm_source", "mcp");
         u.searchParams.set("utm_medium", "mcp-app");
         u.searchParams.set("utm_campaign", "experience-card");
+      }
+      var agentCallId = safeGet(exp, ["_meta", "agent_call_id"]) || exp.agent_call_id;
+      if (agentCallId && !u.searchParams.has("utm_content")) {
+        u.searchParams.set("utm_content", String(agentCallId));
       }
       return u.toString();
     } catch (e) {
@@ -255,11 +262,11 @@ const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
   function metaParts(exp) {
     var parts = [];
     if (exp.city || exp.city_name) parts.push("📍 " + escapeHtml(exp.city || exp.city_name));
-    if (exp.duration_text) parts.push("⏱ " + escapeHtml(exp.duration_text));
+    if (exp.duration_text || exp.duration) parts.push("⏱ " + escapeHtml(exp.duration_text || exp.duration));
     else if (exp.duration_minutes) parts.push("⏱ " + Math.round(exp.duration_minutes) + " min");
-    var rating = num(exp.review_rating || exp.rating);
+    var rating = num(exp.review_rating || exp.reviewRating || exp.rating);
     if (rating != null) {
-      var rc = num(exp.review_count || exp.reviews);
+      var rc = num(exp.review_count || exp.reviewCount || exp.reviews);
       parts.push("⭐ " + rating.toFixed(1) + (rc != null ? " (" + rc + ")" : ""));
     }
     return parts;
@@ -305,7 +312,7 @@ const EXPERIENCE_CARD_HTML = String.raw`<!doctype html>
     }
     var title = exp.title || exp.name || "Untitled";
     var desc = exp.short_description || exp.description || exp.summary || "";
-    var img = exp.hero_image || exp.image || exp.image_url || exp.thumbnail || "";
+    var img = exp.hero_image || exp.image || exp.image_url || exp.imageUrl || exp.thumbnail || "";
     var price = formatPrice(exp);
     var url = getBookingUrl(exp);
     var meta = metaParts(exp);
@@ -523,8 +530,8 @@ const EXPERIENCE_MAP_HTML = String.raw`<!doctype html>
 
   function isPopular(exp) {
     if (exp.popular === true) return true;
-    var rating = num(exp.review_rating || exp.rating);
-    var reviews = num(exp.review_count || exp.reviews);
+    var rating = num(exp.review_rating || exp.reviewRating || exp.rating);
+    var reviews = num(exp.review_count || exp.reviewCount || exp.reviews);
     return rating != null && reviews != null && rating >= 4.5 && reviews >= 100;
   }
 
@@ -537,18 +544,24 @@ const EXPERIENCE_MAP_HTML = String.raw`<!doctype html>
   }
 
   function priceShort(exp) {
-    var p = num(exp.minimal_price != null ? exp.minimal_price : exp.price);
+    var rawPrice = exp.minimal_price != null
+      ? exp.minimal_price
+      : (exp.priceAmount != null ? exp.priceAmount : (exp.price && typeof exp.price === "object" ? exp.price.amount : exp.price));
+    var p = num(rawPrice);
     if (p == null) return "";
-    var ccy = exp.currency || exp.currency_code || "USD";
+    var ccy = exp.currency || exp.currency_code || exp.priceCurrency || (exp.price && exp.price.currency) || "USD";
     var sym = ccy === "USD" ? "$" : (ccy === "EUR" ? "€" : (ccy === "GBP" ? "£" : ""));
     var rounded = Math.round(p);
     return sym ? sym + rounded : ccy + " " + rounded;
   }
 
   function priceLong(exp) {
-    var p = num(exp.minimal_price != null ? exp.minimal_price : exp.price);
+    var rawPrice = exp.minimal_price != null
+      ? exp.minimal_price
+      : (exp.priceAmount != null ? exp.priceAmount : (exp.price && typeof exp.price === "object" ? exp.price.amount : exp.price));
+    var p = num(rawPrice);
     if (p == null) return "";
-    var ccy = exp.currency || exp.currency_code || "USD";
+    var ccy = exp.currency || exp.currency_code || exp.priceCurrency || (exp.price && exp.price.currency) || "USD";
     try {
       return new Intl.NumberFormat(undefined, {
         style: "currency", currency: ccy,
@@ -560,7 +573,7 @@ const EXPERIENCE_MAP_HTML = String.raw`<!doctype html>
   }
 
   function getBookingUrl(exp) {
-    var raw = exp.booking_url || exp.book_url || exp.url || exp.link || "";
+    var raw = exp.booking_url || exp.bookingUrl || exp.book_url || exp.url || exp.link || "";
     if (!raw) return "";
     try {
       var u = new URL(raw, "https://www.tickadoo.com");
@@ -568,6 +581,10 @@ const EXPERIENCE_MAP_HTML = String.raw`<!doctype html>
         u.searchParams.set("utm_source", "mcp");
         u.searchParams.set("utm_medium", "mcp-app");
         u.searchParams.set("utm_campaign", "experience-map");
+      }
+      var agentCallId = safeGet(exp, ["_meta", "agent_call_id"]) || exp.agent_call_id;
+      if (agentCallId && !u.searchParams.has("utm_content")) {
+        u.searchParams.set("utm_content", String(agentCallId));
       }
       return u.toString();
     } catch (e) {
@@ -577,14 +594,14 @@ const EXPERIENCE_MAP_HTML = String.raw`<!doctype html>
 
   function panelMeta(exp) {
     var parts = [];
-    var rating = num(exp.review_rating || exp.rating);
+    var rating = num(exp.review_rating || exp.reviewRating || exp.rating);
     if (rating != null) {
-      var rc = num(exp.review_count || exp.reviews);
+      var rc = num(exp.review_count || exp.reviewCount || exp.reviews);
       parts.push("⭐ " + rating.toFixed(1) + (rc != null ? " (" + rc + ")" : ""));
     }
     if (exp.distance_text) parts.push("📍 " + escapeHtml(exp.distance_text));
     else if (exp.distance_km != null) parts.push("📍 " + Number(exp.distance_km).toFixed(1) + " km");
-    if (exp.duration_text) parts.push("⏱ " + escapeHtml(exp.duration_text));
+    if (exp.duration_text || exp.duration) parts.push("⏱ " + escapeHtml(exp.duration_text || exp.duration));
     return parts.join(" · ");
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,12 +12,15 @@ import { createTickadooServer } from "./shared/server.js";
 import { SERVER_VERSION, SERVER_NAME } from "./shared/config.js";
 import { buildServerManifest, buildAgentCard } from "./shared/discovery.js";
 import { buildLlmsTxt, buildLlmsFullTxt } from "./shared/llms.js";
+import { createTelemetrySql } from "./shared/telemetry.js";
+import { fetchTelemetryDashboard, TELEMETRY_DASHBOARD_HTML } from "./shared/telemetry-dashboard.js";
 
 /* ---------- helpers ---------- */
 
 const CACHE_1H = "public, max-age=3600";
 const CACHE_5M = "public, max-age=300, stale-while-revalidate=300";
 const CACHE_1M = "public, max-age=60, stale-while-revalidate=300";
+const CACHE_NO_STORE = "no-store";
 
 function jsonResponse(data: unknown, opts?: { status?: number; cache?: string }) {
   return new Response(JSON.stringify(data), {
@@ -61,7 +64,7 @@ function buildHealthPayload() {
 
 /* ---------- Hono app ---------- */
 
-const app = new Hono();
+const app = new Hono<{ Bindings: { NEON_URL?: string } }>();
 
 app.use("*", cors({ origin: "*" }));
 
@@ -79,6 +82,30 @@ app.get("/.well-known/mcp.json", () => jsonResponse(buildServerManifest(), { cac
 
 // .well-known/agent-card.json
 app.get("/.well-known/agent-card.json", () => jsonResponse(buildAgentCard(), { cache: CACHE_1H }));
+
+// TODO: Gate these admin telemetry routes behind the shared admin auth middleware once one exists in this repo.
+app.get("/admin/telemetry", () =>
+  textResponse(TELEMETRY_DASHBOARD_HTML, {
+    contentType: "text/html; charset=utf-8",
+    cache: CACHE_NO_STORE,
+  })
+);
+
+app.get("/admin/telemetry.json", async (c) => {
+  const sql = createTelemetrySql(c.env.NEON_URL ?? process.env.NEON_URL);
+  if (!sql) {
+    return jsonResponse({ error: "NEON_URL is not configured" }, { status: 500, cache: CACHE_NO_STORE });
+  }
+
+  try {
+    return jsonResponse(await fetchTelemetryDashboard(sql), { cache: CACHE_NO_STORE });
+  } catch (error) {
+    return jsonResponse(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500, cache: CACHE_NO_STORE },
+    );
+  }
+});
 
 // MCP endpoint
 app.all("/mcp", async (c) => {
@@ -104,7 +131,9 @@ app.all("/mcp", async (c) => {
   }
 
   // MCP transport (stateless, JSON response mode)
-  const server = createTickadooServer();
+  const server = createTickadooServer({
+    telemetrySql: createTelemetrySql(c.env.NEON_URL ?? process.env.NEON_URL),
+  });
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -60,7 +60,10 @@ describe("discovery routes", () => {
     expect(payload._meta["io.modelcontextprotocol.registry/publisher-provided"].tools.map((tool: { name: string }) => tool.name)).toEqual(
       expect.arrayContaining([
         "search_experiences",
+        "search_by_mood",
         "get_last_minute",
+        "find_nearby_experiences",
+        "check_availability",
         "get_related_experiences",
         "get_travel_tips",
         "get_transfer_info",

--- a/tests/llms.test.ts
+++ b/tests/llms.test.ts
@@ -125,6 +125,9 @@ describe("llms docs", () => {
 
     for (const snippet of [
       "search_experiences",
+      "search_by_mood",
+      "find_nearby_experiences",
+      "compare_experiences",
       "get_related_experiences",
       "whats_on_tonight",
       "get_whats_on_this_week",
@@ -134,12 +137,15 @@ describe("llms docs", () => {
       "get_family_day",
       "product_id (required): source experience slug",
       "context (optional): pair, after, nearby, or similar. Default pair",
+      "mood (required): valid enum adventurous, romantic, relaxing, family_fun, cultural, thrill_seeking, foodie, budget_friendly, luxury, rainy_day",
+      "city (required): city name or slug such as london, new-york, paris, tokyo, or dubai",
     ]) {
       expect(fullDoc).toContain(snippet);
     }
 
     for (const snippet of [
       "- search_experiences:",
+      "- search_by_mood:",
       "- get_related_experiences:",
       "- whats_on_tonight:",
       "- get_city_guide:",

--- a/tests/search-sort.test.ts
+++ b/tests/search-sort.test.ts
@@ -37,6 +37,22 @@ function makeProduct(overrides: Partial<Product>): Product {
     currency: "GBP",
     address: null,
     minPrice: 25,
+    mcpProduct: {
+      niceId: 1,
+      name: "Product",
+      url: "product-slug",
+      minPrice: 25,
+      reviewRating: 4.8,
+      reviewCount: 500,
+      indoorOutdoor: "Indoor",
+      physicalLevel: "Easy",
+      audience: ["Couples"],
+      tags: ["Evening"],
+      wheelchairAccessible: true,
+      strollerFriendly: false,
+      languageOptions: ["en"],
+      variants: [],
+    },
     ...overrides,
   };
 }

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { extractTopProductIds, inferHostHint, stampAgentCallId } from "../src/shared/telemetry.js";
+
+describe("telemetry helpers", () => {
+  describe("inferHostHint", () => {
+    it("recognises Claude UA", () => {
+      expect(inferHostHint("Mozilla/5.0 Claude/1.0", "")).toBe("claude");
+    });
+
+    it("recognises Anthropic origin", () => {
+      expect(inferHostHint("", "https://anthropic.com")).toBe("claude");
+    });
+
+    it("recognises ChatGPT origin", () => {
+      expect(inferHostHint("", "https://chatgpt.com")).toBe("chatgpt");
+    });
+
+    it("recognises Goose UA", () => {
+      expect(inferHostHint("goose/0.9", "")).toBe("goose");
+    });
+
+    it("recognises VS Code UA", () => {
+      expect(inferHostHint("vscode-1.96", "")).toBe("vscode");
+    });
+
+    it("falls back to unknown", () => {
+      expect(inferHostHint("MysteryBot/1.0", "")).toBe("unknown");
+    });
+  });
+
+  describe("extractTopProductIds", () => {
+    it("extracts from results array", () => {
+      const sc = { results: [{ slug: "wicked" }, { slug: "lion-king" }, { slug: "tower" }, { slug: "fourth" }] };
+      expect(extractTopProductIds(sc)).toEqual(["wicked", "lion-king", "tower"]);
+    });
+
+    it("extracts from single experience", () => {
+      const sc = { experience: { slug: "wicked" } };
+      expect(extractTopProductIds(sc)).toEqual(["wicked"]);
+    });
+
+    it("extracts top-level slug for details payloads", () => {
+      const sc = { slug: "wicked", details: { currencyCode: "GBP" } };
+      expect(extractTopProductIds(sc)).toEqual(["wicked"]);
+    });
+
+    it("returns empty for malformed input", () => {
+      expect(extractTopProductIds(null)).toEqual([]);
+      expect(extractTopProductIds(undefined)).toEqual([]);
+      expect(extractTopProductIds("nope")).toEqual([]);
+    });
+  });
+
+  describe("stampAgentCallId", () => {
+    it("stamps top-level and per-result _meta", () => {
+      const sc: any = { results: [{ slug: "a" }, { slug: "b" }] };
+      stampAgentCallId(sc, "abc123");
+      expect(sc._meta.agent_call_id).toBe("abc123");
+      expect(sc.results[0]._meta.agent_call_id).toBe("abc123");
+      expect(sc.results[1]._meta.agent_call_id).toBe("abc123");
+    });
+
+    it("stamps experiences list _meta", () => {
+      const sc: any = { experiences: [{ slug: "a" }, { slug: "b" }] };
+      stampAgentCallId(sc, "exp123");
+      expect(sc._meta.agent_call_id).toBe("exp123");
+      expect(sc.experiences[0]._meta.agent_call_id).toBe("exp123");
+      expect(sc.experiences[1]._meta.agent_call_id).toBe("exp123");
+    });
+
+    it("stamps single-experience _meta", () => {
+      const sc: any = { experience: { slug: "wicked" } };
+      stampAgentCallId(sc, "xyz789");
+      expect(sc._meta.agent_call_id).toBe("xyz789");
+      expect(sc.experience._meta.agent_call_id).toBe("xyz789");
+    });
+
+    it("preserves existing _meta entries", () => {
+      const sc: any = { _meta: { utm_source: "partner_xyz" }, results: [{ slug: "a" }] };
+      stampAgentCallId(sc, "id1");
+      expect(sc._meta.utm_source).toBe("partner_xyz");
+      expect(sc._meta.agent_call_id).toBe("id1");
+    });
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,14 @@
       "destination": "/api/health"
     },
     {
+      "source": "/admin/telemetry",
+      "destination": "/api/admin-telemetry-page"
+    },
+    {
+      "source": "/admin/telemetry.json",
+      "destination": "/api/admin-telemetry"
+    },
+    {
       "source": "/llms.txt",
       "destination": "/api/llms"
     },


### PR DESCRIPTION
Captures every tools/call with full context for the moat data layer.

Acceptance:
- db/migrations/001_agent_telemetry.sql applied; agent_calls + agent_call_bookings tables exist
- Current UI-wired tools on this branch (find_nearby_experiences and get_experience_details) write agent_calls rows on every invocation
- agent_call_id injected into structuredContent._meta so widget Book CTAs emit utm_content
- /admin/telemetry dashboard renders 24h volume, by-tool, by-host, by-city, top-products

Live deploy pending: mcp.tickadoo.com redeploy. No Neon schema conflicts with open PRs #76 or #77.

Follow-up in tickadoo/howard: agent_call_bookings INSERT when booking webhook utm_content matches first 8 hex chars of agent_calls.id.

Adaptations from spec:
- Started a new db/migrations/ directory at 001 because this branch had no existing migration files
- Used MCP SDK extra.requestInfo instead of extra.request on @modelcontextprotocol/sdk 1.29.0
- Wrapped the two UI-wired tools present on tickadoo/main; get_related_experiences is not on this branch yet
- Applied and verified the Neon migration with @neondatabase/serverless because psql is not installed in this environment
