### PR TITLE
fix(widgets-worker): correct zone_id to tickadoo.com

### DIFF
--- a/widgets-worker/wrangler.toml
+++ b/widgets-worker/wrangler.toml
@@ -5,7 +5,7 @@ account_id = "e4374ada916c35df9b0090cea132b65b"
 
 [[routes]]
 pattern = "widgets.tickadoo.com/*"
-zone_id = "a06ca0027303da7ab46f4200dfd000cc"
+zone_id = "9e257d33dcd351708e4614d712f62f29"
 
 [vars]
 MCP_INTERNAL_URL = "https://mcp.tickadoo.com"


### PR DESCRIPTION
One-line zone_id fix in `widgets-worker/wrangler.toml`.

**Was:** `zone_id = "a06ca0027303da7ab46f4200dfd000cc"` (britishtheatre.com)
**Now:** `zone_id = "9e257d33dcd351708e4614d712f62f29"` (tickadoo.com)

This was the root cause of Codex F's `Authentication error [code: 10000]` on `/zones/.../workers/routes` during DEPLOY 2 in the moat sprint: wrangler was trying to attach the `widgets.tickadoo.com/*` route to the wrong zone.

**Caveat:** the GH Actions `CF_API_TOKEN` secret in this repo also needs `Zone.Workers Routes: Edit` scope on the tickadoo.com zone for the deploy to succeed. If it does not, the deploy job will fail at the route-attach step with the same 10000 error, but the worker code upload itself will still succeed (as it does today).

After merge + successful deploy, a proxied DNS record for `widgets.tickadoo.com` will need to be created on the tickadoo.com CF zone for traffic to actually reach the worker.

Claude-Chat: tickadooMCP7