### PR TITLE
fix(widgets-worker): revert routes to pattern + zone_id (deploy failure recovery)

### DIFF
--- a/widgets-worker/wrangler.jsonc
+++ b/widgets-worker/wrangler.jsonc
@@ -13,8 +13,8 @@
 	},
 	"routes": [
 		{
-			"pattern": "widgets.tickadoo.com",
-			"custom_domain": true
+			"pattern": "widgets.tickadoo.com/*",
+			"zone_id": "9e257d33dcd351708e4614d712f62f29"
 		}
 	],
 	"vars": {


### PR DESCRIPTION
## What

Reverts ONLY the `routes` block in `widgets-worker/wrangler.jsonc` from `custom_domain: true` back to the prior `pattern` + `zone_id` format.

## Why

PR #83 deploy failed at the `Deploy widgets-worker` step. The `Deploy main MCP worker` step in the same job succeeded with the same `CF_API_TOKEN`, so the token works for at least one Worker on the account.

Most likely cause: the new `custom_domain: true` requires either Zone-level Edit perms the token lacks, or wrangler is unable to recreate a binding that already exists. The previous pattern + zone_id format had been working through 6+ widgets-worker deploys in mid-April.

## Live state at time of fix

- /health on widgets.tickadoo.com returns 200 - old code is still serving traffic (deploy failure was a no-op for live)
- /map and /trio respond as expected (403 on unregistered partner key)
- mcp.tickadoo.com still on Vercel (DNS unchanged)
- howard 21 tools at concierge.tickadoo.com unaffected

## Risk

Minimal. 2-line revert restores the exact route configuration that was working before. All other PR #83 improvements (jsonc syntax, observability, hardened code, SLUG_REGEX validation, CSP, etc.) retained.

Claude-Chat: tickadooMCP-GRO-272-PRE-B
