### PR TITLE
fix(widgets-worker): bypass CF edge cache for /api/widget/cards proxy

### DIFF
--- a/widgets-worker/src/index.ts
+++ b/widgets-worker/src/index.ts
@@ -297,6 +297,7 @@ app.get("/api/widget/cards", async (c) => {
 
   const response = await fetch(upstream, {
     headers: { accept: "application/json" },
+    cf: { cacheTtl: 0, cacheEverything: false },
   });
 
   return new Response(response.body, {


### PR DESCRIPTION
## What

Adds `cf: { cacheTtl: 0, cacheEverything: false }` to the upstream fetch in the `/api/widget/cards` proxy.

## Why

Diagnosed during the DNS flip rollout (GRO-272). After flipping `mcp.tickadoo.com` from Vercel to howard-api:

- Direct curl to `https://mcp.tickadoo.com/api/widget/cards?ids=test` → 200 with `{"_product_map":{}}`
- Through widgets-worker proxy at `https://widgets.tickadoo.com/api/widget/cards?ids=test` → 404 with `{"error":"not found"}`
- Concierge upstream tested as control: `https://concierge.tickadoo.com/api/widget/cards?ids=test` → 200 ✅

The widgets-worker `fetch()` to `mcp.tickadoo.com` was hitting CF edge cache that had a stale 404 from when Vercel was the origin (Vercel didn't have this endpoint). Cache-busting query params didn't help because the fetch is happening server-side.

`cf: { cacheTtl: 0 }` forces the subrequest to go to origin every time, bypassing the edge cache.

## Risk

Tiny. Affects only one fetch in one route. Worst case: slightly slower /api/widget/cards (no edge cache benefit), but this endpoint is small and called rarely.

Claude-Chat: tickadooMCP-GRO-272-FIX
