### PR TITLE
fix(widgets-worker): force fresh upstream fetch for /api/widget/cards

### DIFF
--- a/widgets-worker/src/index.ts
+++ b/widgets-worker/src/index.ts
@@ -297,6 +297,7 @@ app.get("/api/widget/cards", async (c) => {
 
   const response = await fetch(upstream, {
     headers: { accept: "application/json" },
+    cf: { cacheTtl: 0, cacheEverything: false },
   });
 
   return new Response(response.body, {

--- a/widgets-worker/src/index.ts
+++ b/widgets-worker/src/index.ts
@@ -296,8 +296,16 @@ app.get("/api/widget/cards", async (c) => {
   if (ids) upstream.searchParams.set("ids", ids);
 
   const response = await fetch(upstream, {
-    headers: { accept: "application/json" },
-    cf: { cacheTtl: 0, cacheEverything: false },
+    headers: {
+      accept: "application/json",
+      "cache-control": "no-cache",
+      pragma: "no-cache",
+    },
+    cf: {
+      cacheTtl: 0,
+      cacheEverything: false,
+      cacheKey: `widget-cards-${ids ?? "empty"}-${Date.now()}`,
+    },
   });
 
   return new Response(response.body, {


### PR DESCRIPTION
Three layers of cache bypass: unique cf.cacheKey per request, no-cache headers, and cacheTtl: 0. Diagnosed during DNS flip rollout — widgets-worker fetch to mcp.tickadoo.com was hitting stale 404 from when Vercel was the origin.

Claude-Chat: tickadooMCP-GRO-272-FIX2