### PR TITLE
fix(widgets-worker): 3-layer cache bypass for /api/widget/cards

### DIFF
--- a/widgets-worker/src/index.ts
+++ b/widgets-worker/src/index.ts
@@ -296,8 +296,16 @@ app.get("/api/widget/cards", async (c) => {
   if (ids) upstream.searchParams.set("ids", ids);
 
   const response = await fetch(upstream, {
-    headers: { accept: "application/json" },
-    cf: { cacheTtl: 0, cacheEverything: false },
+    headers: {
+      accept: "application/json",
+      "cache-control": "no-cache",
+      pragma: "no-cache",
+    },
+    cf: {
+      cacheTtl: 0,
+      cacheEverything: false,
+      cacheKey: `widget-cards-${ids ?? "empty"}-${Date.now()}`,
+    },
   });
 
   return new Response(response.body, {


### PR DESCRIPTION
3 layers: unique cf.cacheKey, no-cache HTTP headers, cacheTtl: 0. Followup to PR #86 which only had cacheTtl. Diagnosed during DNS flip rollout (GRO-272).

Claude-Chat: tickadooMCP-GRO-272-FIX2