### PR TITLE
fix(mcp-apps): set openai/widgetAccessible on widget descriptors (GRO-502 parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- `uiMeta()` now sets `openai/widgetAccessible: true` on the experience-card, experience-map, and experience-trio descriptors. Without it ChatGPT blocks the widget from calling `tools/call` back into the server (card -> `check_availability`, map pin -> `get_experience_details`), so the inline callback chain was dead. Matches the HowardOS render tool (GRO-496a). New optional `accessible` flag on `uiMeta` defaults to `true`; pass `false` to opt a static widget out. (GRO-502 parity)
+
 ### Security
 - Admin telemetry routes (`/admin/telemetry`, `/admin/telemetry.json`) now require `Authorization: Bearer $ADMIN_TOKEN` with a constant-time compare. Missing secret returns 503 to fail closed.
 - Scrub telemetry `input_args` against a whitelist of tool-parameter keys before persisting to Neon; freetext dropped, strings capped at 120 chars, arrays at 10, nested objects dropped.

--- a/src/shared/ui-resources.ts
+++ b/src/shared/ui-resources.ts
@@ -32,21 +32,29 @@ export const EXPERIENCE_TRIO_URI = "ui://tickadoo/experience-trio.html";
  */
 export function uiMeta(
   uri: string,
-  hints?: { invoking?: string; invoked?: string },
+  hints?: { invoking?: string; invoked?: string; accessible?: boolean },
 ): {
   ui: { resourceUri: string };
   "openai/outputTemplate": string;
+  "openai/widgetAccessible": boolean;
   "openai/toolInvocation/invoking"?: string;
   "openai/toolInvocation/invoked"?: string;
 } {
+  // widgetAccessible defaults true: every tool that renders one of these
+  // resources needs its widget to call tools/call back into the server (card
+  // -> check_availability, map pin -> get_experience_details, etc.). Without
+  // it ChatGPT blocks the callback. Matches the HowardOS render tool (GRO-496a).
+  const accessible = hints?.accessible ?? true;
   const meta: {
     ui: { resourceUri: string };
     "openai/outputTemplate": string;
+    "openai/widgetAccessible": boolean;
     "openai/toolInvocation/invoking"?: string;
     "openai/toolInvocation/invoked"?: string;
   } = {
     ui: { resourceUri: uri },
     "openai/outputTemplate": uri,
+    "openai/widgetAccessible": accessible,
   };
   if (hints?.invoking) meta["openai/toolInvocation/invoking"] = hints.invoking;
   if (hints?.invoked) meta["openai/toolInvocation/invoked"] = hints.invoked;

--- a/tests/ui-resources.test.ts
+++ b/tests/ui-resources.test.ts
@@ -45,6 +45,18 @@ describe("ui-resources", () => {
     expect(meta["openai/toolInvocation/invoked"]).toBe("Done");
   });
 
+  it("uiMeta marks the widget accessible by default (GRO-496a parity)", () => {
+    // Required so the rendered widget can call tools/call back into the server
+    // (card -> check_availability, map pin -> get_experience_details).
+    const meta = uiMeta(EXPERIENCE_CARD_URI);
+    expect(meta["openai/widgetAccessible"]).toBe(true);
+  });
+
+  it("uiMeta allows opting a widget out of callbacks", () => {
+    const meta = uiMeta(EXPERIENCE_CARD_URI, { accessible: false });
+    expect(meta["openai/widgetAccessible"]).toBe(false);
+  });
+
   it("experience-card HTML carries the required markers and UTM attribution", () => {
     const card = TICKADOO_UI_RESOURCES.find(r => r.name === "experience-card");
     expect(card).toBeDefined();


### PR DESCRIPTION
Part of GRO-502 (downstream parity with the GRO-491 / 2026-07-28 work in HowardOS).

## The gap
`uiMeta()` emitted `ui.resourceUri` + `openai/outputTemplate` + invocation hints but **not** `openai/widgetAccessible`. Without that key ChatGPT blocks the rendered widget from calling `tools/call` back into the server, so the inline callback chain was dead for all three widget tools:
- experience-card -> `check_availability`
- experience-map pin -> `get_experience_details`
- experience-trio

This is the same blocker fixed on the canonical HowardOS render tool in **GRO-496a** (#1718). This brings the downstream `@tickadoo/mcp-server` package into parity.

## Change
- `uiMeta()` now sets `openai/widgetAccessible`, defaulting `true` (every current caller renders an interactive widget that needs callbacks). New optional `accessible` flag lets a static widget opt out.
- `tests/ui-resources.test.ts`: +2 cases (default true, explicit opt-out). Suite is **net +2 passing vs main, zero new failures** — the 20 pre-existing network/setup file-failures are identical on clean `main`.
- CHANGELOG `[Unreleased] Fixed` entry. Version bump left to the release cut.

## Note
`widgets-worker/` had unrelated uncommitted WIP (a `HOWARD_API` service binding) in the working tree; I deliberately left it unstaged and out of this PR.

## Context: rest of GRO-502
The protocol-layer RC conformance for this package is governed by `@modelcontextprotocol/sdk` (it uses `McpServer`, not a hand-rolled dispatcher), currently `^1.29.0` = latest. So unlike HowardOS, no manual server/discover / routing-header / error-code work is needed here — the SDK provides it. The content/descriptor parity (this PR) is the part this repo actually owns.