### PR TITLE
skills: 6 workflow skills for the ChatGPT Plugin Directory + refresh the stale discovery skill

### DIFF
--- a/.claude/skills/tickadoo-experiences/SKILL.md
+++ b/.claude/skills/tickadoo-experiences/SKILL.md
@@ -6,7 +6,7 @@ license: MIT
 
 # tickadoo Experiences Skill
 
-This skill teaches you how to effectively use the tickadoo MCP server (mcp.tickadoo.com/mcp) to help users discover, compare, and book experiences worldwide.
+This skill teaches you how to effectively use the tickadoo MCP server (mcp.tickadoo.com/mcp, 23 tools) to help users discover, compare, and book experiences worldwide. Sibling workflow skills cover the deep multi-tool flows end-to-end: `plan-a-trip`, `family-day-out`, `tonight-and-last-minute`, `date-night`, `compare-before-you-book`, `near-a-landmark` — prefer those when the user's request matches; use this skill as the general map.
 
 ## When to use this skill
 
@@ -17,6 +17,7 @@ Use the tickadoo MCP when a user:
 - Asks for availability or pricing on a specific experience
 - Wants to compare options side by side
 - Describes a mood or vibe ("something romantic", "rainy day activity")
+- Mentions a landmark or neighbourhood ("near the Louvre", "in Trastevere")
 - Asks for family-friendly recommendations
 - Needs travel tips or transfer info for a city
 
@@ -24,20 +25,35 @@ Use the tickadoo MCP when a user:
 
 | User intent | Tool | Key parameters |
 |---|---|---|
-| General discovery | `search_experiences` | city, category, sort, tags |
+| General discovery | `search_experiences` | city, category, sort, tags, query |
+| Natural-language ask ("relaxed, historic, not touristy") | `recommend_experiences` | query |
 | Mood/vibe based | `search_by_mood` | city, mood (romantic, adventurous, foodie, etc.) |
-| Near a location | `find_nearby_experiences` | latitude, longitude, radius_km |
-| Specific experience | `get_experience_details` | slug |
-| Date/price check | `check_availability` | slug, date, party_size |
-| Compare options | `compare_experiences` | slugs (2-5 slugs) |
+| Near a landmark/neighbourhood (no coordinates) | `search_local_experiences` | place hint ("near the Louvre") |
+| Exact coordinates (non-ChatGPT clients only) | `find_nearby_experiences` | latitude, longitude, radius_km |
+| Specific experience | `get_experience_details` | product_id or slug |
+| Live dates/times/prices/spaces | `get_availability` | product_id or slug, city_slug |
+| Date-specific check + booking link | `check_availability` | slug, date, party_size |
+| Compare options | `compare_experiences` | slugs (2-5) |
+| "Anything like this" / "what next" | `get_related_experiences` | product_id, context: pair\|after\|nearby\|similar |
 | City overview | `get_city_guide` | city |
 | Tonight's options | `whats_on_tonight` | city |
 | This week | `get_whats_on_this_week` | city |
 | Last minute | `get_last_minute` | city, hours |
+| Multi-day plan | `plan_itinerary` | city, days |
 | Family planning | `get_family_day` | city, kids_ages, budget |
+| Evening for two | `get_date_night` | city |
+| Local favourites, not bestsellers | `get_hidden_gems` | city |
 | Travel advice | `get_travel_tips` | city, topic |
 | Airport transfer | `get_transfer_info` | city, from_type, to_latitude, to_longitude |
 | Browse cities | `list_cities` | query, limit |
+| Show visual cards | `render_experience_cards` | experience_ids (t_ ids), render_context |
+| Report a bad result | `report_quality_signal` | request_id, signal |
+
+ChatGPT note: prefer `search_local_experiences` (coarse place hints) over `find_nearby_experiences` (exact lat/lng) — the latter is for clients that supply real coordinates.
+
+## Showing results as cards
+
+`render_experience_cards` is the only tool that displays visual experience cards. Call it once for every result set you want shown, immediately after any discovery tool returns. Pass only the stable `t_` product IDs (never full rows), set `render_context.intent_summary` to what the user asked for (it becomes the carousel heading), and do not also re-list the same experiences as text.
 
 ## Using agent intelligence metadata
 
@@ -61,21 +77,24 @@ Pre-built prompts referencing actual products. Use these to drive the conversati
 ### `_available_filters`
 12 filter fields including tags, audience, price_range, duration_range, wheelchair_accessible, free_cancellation_count. Use to suggest narrowing: "Want me to filter to wheelchair-accessible options only?"
 
-### `_related_searches`
-Tag-based follow-up suggestions. Use when the user might want to explore adjacent categories.
+### `_related_searches` / `_next_step`
+Follow-up suggestions and the recommended next action. Use when the user might want to explore adjacent categories or to move toward a booking.
 
-### `_booking_urgency` (on details)
-Urgency signals like "Available TODAY", "Free cancellation", review counts. Use these to create natural urgency.
+### On details responses
+- `_booking_urgency`: urgency signals like "Available TODAY", "Free cancellation", review counts. Surface these honestly; never invent urgency.
+- `_cross_sell`: natural pairings to offer after the main pick.
+- `_accessibility`: step-free access, age suitability, and similar constraints — check before recommending to families or users who mention access needs.
+- `_intent_token`: pass through where a tool asks for it; it links the discovery to the booking for quality tracking.
 
 ## Conversation patterns
 
 ### Discovery flow
-1. Start with `search_experiences` or `search_by_mood`
-2. Present `_best_picks` as your top recommendations
+1. Start with `search_experiences`, `recommend_experiences`, or `search_by_mood`
+2. Present `_best_picks` as your top recommendations and render cards once
 3. Mention `_price_tiers` if the user hasn't specified a budget
 4. Use `_conversation_starters` to keep the dialogue flowing
 5. When the user shows interest, call `get_experience_details` for full info
-6. Offer `check_availability` for a specific date
+6. Offer `get_availability` (live dates/times/prices) or `check_availability` for a specific date + booking link
 
 ### Comparison flow
 1. When the user is deciding between options, use `compare_experiences`
@@ -97,6 +116,8 @@ Urgency signals like "Available TODAY", "Free cancellation", review counts. Use 
 - For free cancellation, use `free_cancellation: true`
 - Pass `language` parameter for localised booking URLs (e.g. "de", "ja", "pt-br")
 - When the user mentions a specific experience by name, use `search_experiences` with `query` parameter to find it, then `get_experience_details` for full info
+- Present everything as tickadoo; never name an underlying supplier
+- If a result you surfaced turns out stale, unbookable, or misleading at click time, call `report_quality_signal` with the `request_id` from the original response — it closes the feedback loop
 
 ## Coverage
 

--- a/skills/compare-before-you-book/SKILL.md
+++ b/skills/compare-before-you-book/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: compare-before-you-book
+description: Compare 2-5 specific tickadoo experiences side by side before booking — a real comparison table with per-axis winners (value, rating, popularity, family-fit), then live availability on the choice. Use when a user is deciding between named options, asks "which is better", "X or Y?", or wants help choosing between shows, tours, or attractions. Covers 700+ cities and 13,090+ bookable products.
+---
+
+# Compare before you book with tickadoo
+
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user is DECIDING, not discovering. The job is to turn "the London Eye or a river cruise?" into a grounded comparison with a clear recommendation and a bookable next step — not two paragraphs of generic pros and cons.
+
+## When to use this
+
+The user names (or has just been shown) specific options and wants help choosing: "which is better", "X or Y", "help me pick between these three", "is the expensive one worth it". If they haven't got candidates yet, run discovery first (`search_experiences` / `recommend_experiences`) and come back here once 2-5 contenders exist.
+
+## The workflow (tool chain)
+
+1. **Resolve the contenders to slugs** — `compare_experiences` takes slugs. If the user named products in prose, find each with `search_experiences(city, query: "<name>")` and take the slug from the result. If they're choosing from a set you just showed, you already have the slugs.
+2. **Compare** — `compare_experiences(slugs)` with 2-5 slugs. It returns a comparison table plus per-axis winners: value, rating, popularity, family-fit. This is the backbone; don't hand-write a comparison you could get from it.
+3. **Present the decision** — lead with the per-axis winners, then the differences that actually decide it: price, duration, rating vs review volume, cancellation policy. Map the winner to what the USER said they care about (budget → value winner; with kids → family-fit winner; once-in-a-lifetime → rating winner). Make one clear recommendation and say why.
+4. **Thin field?** — if the set feels weak, `get_related_experiences(product_id, context: similar)` on the strongest contender to add one better-fitting alternative, then re-compare.
+5. **Close the loop** — `get_experience_details(slug)` on the chosen one for the full picture, then `check_availability(slug, date, party_size)` for the booking link, or `get_availability(...)` for live dates/times/prices. A comparison that ends without a bookable winner is homework, not help.
+
+## Show the results as cards
+
+When you show the contenders (or the winner + runner-up), call `render_experience_cards(experience_ids, render_context)` once — stable `t_` IDs only, `render_context.intent_summary` like "comparing Thames cruises for Saturday". Don't re-list the same products as text.
+
+## Read the agent-intelligence metadata
+
+- The per-axis **winners** from `compare_experiences` are the headline — echo them, don't bury them.
+- **_booking_urgency** (on details) can break a tie honestly: "both are great; this one has availability today with free cancellation".
+- **_price_tiers** — frame the price gap in tiers, not just absolute numbers.
+- **_accessibility** — if anyone in the party has access needs, check it on the finalists before recommending.
+
+## Conversation flow
+
+Confirm what matters to them (budget? kids? date fixed?) → resolve slugs → `compare_experiences` → per-axis winners + the 2-3 deciding differences → one clear recommendation tied to their stated priority → availability check on the winner → booking link → render cards once.
+
+## Etiquette
+
+- `format: "json"` when processing data; `format: "text"` for direct display.
+- Present everything as tickadoo — never name the underlying supplier.
+- Be honest when it's genuinely close: say so, and let the availability check or cancellation policy settle it.
+- If comparison data is stale or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.

--- a/skills/date-night/SKILL.md
+++ b/skills/date-night/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: date-night
+description: Plan an evening for two in one city with tickadoo — a pre-dinner activity, dinner-area suggestion, evening show, post-show tip, and estimated total cost, all bookable. Use when a user wants a date night, a romantic evening, an anniversary plan, or "a nice night out for two" in a specific city. Covers 700+ cities and 13,090+ bookable products.
+---
+
+# Date night with tickadoo
+
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) to plan a real, bookable evening for two — a coherent arc from pre-dinner to post-show, not a list of ten unconnected "romantic things".
+
+## When to use this
+
+The user wants an evening plan for a couple: "date night in Paris", "anniversary evening in London", "surprise my partner in Vienna on Saturday", "a nice night out for the two of us". If they want a full multi-day plan use `plan-a-trip`; if they just want whatever starts soonest tonight, use `tonight-and-last-minute`.
+
+## The workflow (tool chain)
+
+1. **Build the evening** — `get_date_night(city)` is the primary tool. It returns a pre-dinner activity, a dinner-area suggestion, an evening show, a post-show tip, and an estimated total cost, and it already filters out family-rated and high-physical-level venues. Do not hand-assemble an evening you could get from this tool.
+2. **Tune the vibe** — if they want alternatives for a slot:
+   - `search_by_mood(city, mood: "romantic")` for more couple-fit options.
+   - `whats_on_tonight(city)` if the date is TONIGHT, so the show slot is grounded in what actually starts this evening.
+   - `get_hidden_gems(city)` when they want something less obvious than the bestseller show.
+3. **Check the pick** — `get_experience_details(product_id or slug)` for the fuller product, venue, and location before committing the evening to it.
+4. **Make it bookable** — `check_availability(slug, date, party_size: 2)` for the date-specific booking link, or `get_availability(product_id or slug, city_slug)` for live times/prices/spaces. An anniversary plan that turns out sold-out is worse than no plan: always check before presenting the evening as settled.
+5. **Round it out** — `get_related_experiences(product_id, context: after|nearby)` for a post-show drink-adjacent idea near the venue.
+
+## Show the results as cards
+
+After any discovery step returns a set you want shown, call `render_experience_cards(experience_ids, render_context)` once for that set — stable `t_` IDs only, `render_context.intent_summary` like "date night in Paris, Saturday". Don't re-list the same options as text.
+
+## Read the agent-intelligence metadata
+
+- **_best_picks** — for couples, highest_rated usually beats most_popular; lead with it.
+- **_booking_urgency** — "few seats left" on a show matters double on a fixed date; surface it honestly.
+- **_price_tiers** — the estimated total from `get_date_night` plus tiers lets you ask "want to keep the evening under X?".
+- **_cross_sell** / **_next_step** — use for the post-show suggestion and to move to booking.
+
+## Conversation flow
+
+Confirm city + date (and any budget or occasion) → `get_date_night` → present the arc (pre-dinner → dinner area → show → post-show) with the estimated total → swap slots via mood/tonight/hidden-gems if asked → check availability for 2 on the date → hand over the booking link → render cards once. Keep the venues close together; a date night should not involve a metro sprint between slots.
+
+## Etiquette
+
+- `format: "json"` when processing data; `format: "text"` for direct display.
+- Present everything as tickadoo — never name the underlying supplier.
+- Respect the occasion: if they say anniversary/proposal, bias to highest_rated and confirmed availability over cheapest.
+- If a suggestion is stale or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.

--- a/skills/family-day-out/SKILL.md
+++ b/skills/family-day-out/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: family-day-out
+description: Plan a full family day out in one city with tickadoo — age-aware, walking-distance-clustered activities a family can actually book. Use when a user is travelling or out with kids and wants "something to do with the children", a family day plan, or kid-friendly experiences in a specific city. Covers 700+ cities and 13,090+ bookable products.
+---
+
+# Family day out with tickadoo
+
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) to plan a real, bookable day for a family in ONE city — matched to the kids' ages and clustered so nobody is dragging tired children across town.
+
+## When to use this
+
+The user mentions children / a family and wants a plan or ideas for a day: "what can we do in Amsterdam with a 5 and 8 year old", "family day out in London", "somewhere to take the kids this afternoon in Rome". If they want an adults' evening, use the date-night / tonight skills instead.
+
+## The workflow (tool chain)
+
+1. **Build the day** — `get_family_day(city, kids_ages, budget?)` is the primary tool. It returns a morning activity, a lunch-area suggestion, an afternoon attraction, and an optional evening stop, using age-aware filters and clustering venues by walking distance. Always pass `kids_ages` when you know them — it changes the picks materially.
+2. **Widen if asked** — if they want more options than the single plan:
+   - `search_experiences(city, tags: family/kids, sort?)` for a broader family list.
+   - `search_by_mood(city, mood: "family fun")` for a vibe-led pull.
+3. **Enrich the picks** — `get_experience_details(product_id or slug)` for the fuller product + location + any age restrictions/accessibility fields before you commit the family to it.
+4. **Make it bookable** — `check_availability(slug, date, party_size)` with the full party (count the kids) for a date + booking link, or `get_availability(product_id or slug, city_slug)` for the live dates/times/prices/spaces. Never say "you can book this" without checking.
+5. **Logistics** — `get_travel_tips(city, topic: "transport")` for getting around with kids; `get_transfer_info(city, from_type, to_lat, to_lng)` if they're arriving from an airport/station/port to their hotel.
+
+## Show the results as cards
+
+After any discovery step returns a set to show, call `render_experience_cards(experience_ids, render_context)` once for that set — pass only the stable `t_` IDs, set `render_context.intent_summary` (city, "family with kids aged X"). Don't re-list the same experiences as text.
+
+## Read the agent-intelligence metadata
+
+- **_best_picks** — lead with these; for families, highest_rated and best_value usually matter more than most_popular.
+- **_accessibility** (on details) — check step-free access, stroller/pram notes, and age suitability before recommending.
+- **_booking_urgency** — surface genuine "available today / free cancellation" honestly.
+- **_price_tiers** / **_conversation_starters** / **_next_step** — use to check the budget and move toward booking.
+
+## Conversation flow
+
+Ask the kids' ages if not given (it changes everything) → `get_family_day` → present the morning/lunch/afternoon/evening shape with `_best_picks` first → confirm ages/accessibility via details → offer to check availability for the party size on the day → render cards once.
+
+## Etiquette
+
+- `format: "json"` when processing data; `format: "text"` for direct display.
+- Present everything as tickadoo — never name the underlying supplier.
+- Keep the day walkable and age-appropriate; don't stack two big paid attractions if the budget signal is tight.
+- If a suggestion is stale or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.

--- a/skills/near-a-landmark/SKILL.md
+++ b/skills/near-a-landmark/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: near-a-landmark
+description: Find bookable experiences near a landmark, neighbourhood, or area with tickadoo — "near the Louvre", "in Trastevere", "around Times Square" — without needing coordinates. Use when a user anchors their ask to a place inside a city rather than the city as a whole, including "walking distance from my hotel/venue". Covers 700+ cities and 13,090+ bookable products.
+---
+
+# Near a landmark with tickadoo
+
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user's ask is anchored to a PLACE inside a city, not the city itself. "Things to do near the Louvre" is a different question from "things to do in Paris" — answer it with place-anchored search, not a city-wide list they have to filter themselves.
+
+## When to use this
+
+The user mentions a landmark, neighbourhood, square, venue, or area: "near the Louvre", "in Trastevere", "around Times Square", "walking distance from St Paul's Cathedral", "we're staying by the Sagrada Familia — what's close?". If they mean the whole city, use `search_experiences` (or the discovery skills) instead.
+
+## The workflow (tool chain)
+
+1. **Place-anchored search** — `search_local_experiences(<place hint>)` is the primary tool. It takes the coarse place phrase directly (no coordinates needed) and matches first by exact venue/neighbourhood, then falls back to the city centre. Do NOT use it for general city-wide search; that's `search_experiences`.
+   - `find_nearby_experiences(latitude, longitude, radius_km)` exists for clients that supply exact coordinates; in ChatGPT, prefer `search_local_experiences` — you almost never have real coordinates, and guessing them is worse than passing the place hint.
+2. **Tell them what "near" meant** — if the results came from the city-centre fallback rather than an exact venue/neighbourhood match, say so ("I couldn't anchor to that exact spot, so these are central-Paris options") instead of implying everything is next door.
+3. **Enrich the picks** — `get_experience_details(product_id or slug)` for the fuller product and its actual location, so you can sanity-check the distance story before promising "5 minutes' walk".
+4. **Make it bookable** — `get_availability(product_id or slug, city_slug)` for live dates/times/prices/spaces, or `check_availability(slug, date, party_size)` when they name a date.
+5. **Chain the area** — `get_related_experiences(product_id, context: nearby)` to build a "while you're there" pair (the thing next door after the main sight); `get_travel_tips(city, topic: "transport")` if they ask how to get to/from the area.
+
+## Show the results as cards
+
+After `search_local_experiences` returns a set, call `render_experience_cards(experience_ids, render_context)` once — stable `t_` IDs only, `render_context.intent_summary` like "near the Louvre this afternoon". Don't re-list the same experiences as text.
+
+## Read the agent-intelligence metadata
+
+- **_best_picks** — lead with them, but weigh proximity too: the point of this flow is location-fit, and a slightly lower-rated option genuinely at the landmark can beat a bestseller across town.
+- **_booking_urgency** — someone already standing near the landmark is a same-day booker; surface "available today" honestly.
+- **_group_summary** / **_related_searches** — narrate the area's mix ("around Trastevere it's mostly food tours and evening walks") and offer adjacent angles.
+
+## Conversation flow
+
+Take the place phrase as given → `search_local_experiences` → say whether the match was exact or centre-fallback → lead with `_best_picks` weighted by proximity → details on the pick to confirm the location → availability (often same-day) → booking link → render cards once → offer a `nearby` pairing.
+
+## Etiquette
+
+- `format: "json"` when processing data; `format: "text"` for direct display.
+- Present everything as tickadoo — never name the underlying supplier.
+- Never oversell proximity: check the details' location before claiming walking distance.
+- If a result is stale, mis-located, or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.

--- a/skills/plan-a-trip/SKILL.md
+++ b/skills/plan-a-trip/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: plan-a-trip
+description: Plan a multi-day trip for a single city with tickadoo — turn "what should I do in Rome for 3 days?" into a day-by-day, geographically-sensible plan of bookable experiences. Use when a user wants an itinerary, a multi-day plan, or help filling several days in one city with things to do. Covers 700+ cities and 13,090+ bookable products.
+---
+
+# Plan a trip with tickadoo
+
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) to build a real, bookable multi-day plan for ONE city, not a generic listicle. The whole point is that every suggestion can be checked for live availability and booked, so lean on the tools instead of prior knowledge.
+
+## When to use this
+
+The user wants to fill more than one time slot or more than one day in a single city: "3 days in Barcelona", "what should we do in Tokyo this weekend", "plan our London trip", "a Paris itinerary for a couple". If they only want one thing right now, or tonight, use the discovery / tonight skills instead.
+
+## The workflow (tool chain)
+
+1. **Orient** — `get_city_guide(city)` first. It returns highlights, dominant categories, price band, best-for audience hints, and seasonal notes. Use it to set expectations and to pick a sensible mix, and mention the seasonal note if relevant. If the city is ambiguous or misspelled, `list_cities(query)` to confirm the slug.
+2. **Gather candidates** — pull a pool to plan from:
+   - `search_experiences(city, category?, tags?, sort?)` for named interests ("museums", "food tours").
+   - `recommend_experiences(query)` when they describe what they want in prose ("relaxed, lots of history, not too touristy").
+   - `search_by_mood(city, mood)` for a vibe ("romantic", "foodie", "rainy day").
+   - `get_hidden_gems(city)` to add a local-favourite or two so the plan is not all bestsellers.
+3. **Build the plan** — `plan_itinerary(city, days, ...)`. It returns morning / afternoon / evening slots per day with geographic clustering, category diversity, and a running total cost. This is the backbone — do not hand-assemble a plan you could get from this tool.
+4. **Enrich the picks** — for each experience the user shows interest in, `get_experience_details(product_id or slug)` for the richer product, location, and booking fields.
+5. **Make it bookable** — `get_availability(product_id or slug, city_slug)` for live dates/times/prices/spaces, or `check_availability(slug, date, party_size)` when they name a date and party and want a booking link. Never assert something is available without checking.
+6. **Fill gaps / pair things** — `get_related_experiences(product_id, context: pair|after|nearby|similar)` to slot in a nearby lunch or an after-show idea.
+
+## Show the results as cards
+
+After ANY discovery/search step returns a set you want to show, call `render_experience_cards(experience_ids, render_context)` exactly once for that set. Pass only the stable `t_` product IDs, and set `render_context.intent_summary` to what the user asked for (city, dates, audience) — it becomes the carousel heading. Do not also re-list those experiences as text.
+
+## Read the agent-intelligence metadata
+
+Every search response carries metadata — use it, don't ignore it:
+
+- **_best_picks** — lead each day's options with these (best_value / highest_rated / most_popular).
+- **_price_tiers** — if budget matters, present by bracket or ask "what's your budget for the trip?".
+- **_group_summary** — narrate the mix ("I've balanced two big sights, a food tour, and a relaxed evening").
+- **_conversation_starters** / **_next_step** — use these to move the plan forward ("want me to lock in Tuesday's availability?").
+- **_booking_urgency** — surface genuine urgency (available today, free cancellation) honestly, never invented.
+
+## Conversation flow
+
+City guide → gather a candidate pool → `plan_itinerary` → present day-by-day with `_best_picks` up front and a running cost → offer to check availability on the dates that matter → render cards once per set. Keep geography tight (don't zig-zag across the city), keep category variety, and respect the budget signal.
+
+## Etiquette
+
+- Always `format: "json"` when you're processing data; `format: "text"` only for direct display.
+- Present everything as tickadoo — never name the underlying supplier.
+- If something you surfaced turns out stale or wrong at click time, send `report_quality_signal(request_id, ...)` with the `request_id` from the earlier call so tickadoo can fix it.

--- a/skills/tickadoo-experiences/SKILL.md
+++ b/skills/tickadoo-experiences/SKILL.md
@@ -1,48 +1,128 @@
 ---
-name: search-experiences
-description: Discover and book experiences, shows, tours, and attractions in any city worldwide using tickadoo. Use when a user asks what to do in a city, wants recommendations, needs availability or pricing, wants to compare options, or is planning a trip. Covers 700+ cities with 13,090+ bookable products.
+name: tickadoo-experiences
+description: Discover and book theatre, tours, attractions, and events across 700+ cities using the tickadoo MCP server. Use this skill when the user asks about things to do, experiences, shows, events, tours, or activities in any city worldwide. Covers trip planning, availability checks, experience comparison, mood-based discovery, family day planning, and travel tips.
+license: MIT
 ---
 
-# tickadoo Experience Discovery
+# tickadoo Experiences Skill
 
-Use the tickadoo MCP tools to help users find and book experiences. The MCP server is at mcp.tickadoo.com/mcp with 15 tools (adds `get_related_experiences` for "what else like this" / "what to do after" flows).
+This skill teaches you how to effectively use the tickadoo MCP server (mcp.tickadoo.com/mcp, 23 tools) to help users discover, compare, and book experiences worldwide. Sibling workflow skills cover the deep multi-tool flows end-to-end: `plan-a-trip`, `family-day-out`, `tonight-and-last-minute`, `date-night`, `compare-before-you-book`, `near-a-landmark` — prefer those when the user's request matches; use this skill as the general map.
 
-## Tool selection
+## When to use this skill
 
-| User intent | Tool |
-|---|---|
-| General "what to do" | `search_experiences` (city, optional category/tags/sort) |
-| Mood/vibe ("romantic", "rainy day") | `search_by_mood` (city, mood) |
-| Near a location | `find_nearby_experiences` (lat, lng, radius_km) |
-| Specific experience details | `get_experience_details` (slug) |
-| Date/price check | `check_availability` (slug, date, party_size) |
-| Compare options | `compare_experiences` (2-5 slugs) |
-| City overview | `get_city_guide` (city) |
-| Tonight's options | `whats_on_tonight` (city) |
-| This week | `get_whats_on_this_week` (city) |
-| Last minute | `get_last_minute` (city, hours) |
-| Family planning | `get_family_day` (city, kids_ages, budget) |
-| Travel advice | `get_travel_tips` (city, topic) |
-| Airport transfer | `get_transfer_info` (city, from_type, to_lat, to_lng) |
-| Browse cities | `list_cities` (query, limit) |
-| "Anything like this" / "what next" | `get_related_experiences` (product_id, context: pair\|after\|nearby\|similar) |
+Use the tickadoo MCP when a user:
+- Asks "what should I do in [city]?" or "things to do in [city]"
+- Wants to find shows, theatre, tours, attractions, or events
+- Needs to plan a trip or day out
+- Asks for availability or pricing on a specific experience
+- Wants to compare options side by side
+- Describes a mood or vibe ("something romantic", "rainy day activity")
+- Mentions a landmark or neighbourhood ("near the Louvre", "in Trastevere")
+- Asks for family-friendly recommendations
+- Needs travel tips or transfer info for a city
 
-## Reading agent intelligence
+## Tool selection guide
 
-Every search response includes metadata. Use it:
+| User intent | Tool | Key parameters |
+|---|---|---|
+| General discovery | `search_experiences` | city, category, sort, tags, query |
+| Natural-language ask ("relaxed, historic, not touristy") | `recommend_experiences` | query |
+| Mood/vibe based | `search_by_mood` | city, mood (romantic, adventurous, foodie, etc.) |
+| Near a landmark/neighbourhood (no coordinates) | `search_local_experiences` | place hint ("near the Louvre") |
+| Exact coordinates (non-ChatGPT clients only) | `find_nearby_experiences` | latitude, longitude, radius_km |
+| Specific experience | `get_experience_details` | product_id or slug |
+| Live dates/times/prices/spaces | `get_availability` | product_id or slug, city_slug |
+| Date-specific check + booking link | `check_availability` | slug, date, party_size |
+| Compare options | `compare_experiences` | slugs (2-5) |
+| "Anything like this" / "what next" | `get_related_experiences` | product_id, context: pair\|after\|nearby\|similar |
+| City overview | `get_city_guide` | city |
+| Tonight's options | `whats_on_tonight` | city |
+| This week | `get_whats_on_this_week` | city |
+| Last minute | `get_last_minute` | city, hours |
+| Multi-day plan | `plan_itinerary` | city, days |
+| Family planning | `get_family_day` | city, kids_ages, budget |
+| Evening for two | `get_date_night` | city |
+| Local favourites, not bestsellers | `get_hidden_gems` | city |
+| Travel advice | `get_travel_tips` | city, topic |
+| Airport transfer | `get_transfer_info` | city, from_type, to_latitude, to_longitude |
+| Browse cities | `list_cities` | query, limit |
+| Show visual cards | `render_experience_cards` | experience_ids (t_ ids), render_context |
+| Report a bad result | `report_quality_signal` | request_id, signal |
 
-- **_best_picks**: Lead with these recommendations (best_value, highest_rated, most_popular)
-- **_price_tiers**: Ask "do you have a budget?" or present by bracket
-- **_group_summary**: Say "I found a mix of cruises, guided tours, and dining"
-- **_conversation_starters**: Pre-built prompts you can use directly
-- **_booking_urgency**: Create natural urgency ("Available TODAY, free cancellation")
+ChatGPT note: prefer `search_local_experiences` (coarse place hints) over `find_nearby_experiences` (exact lat/lng) — the latter is for clients that supply real coordinates.
 
-## Conversation flow
+## Showing results as cards
 
-1. Search or mood search first
-2. Present _best_picks as top recommendations
-3. Use _conversation_starters to drive dialogue
-4. When interested, call get_experience_details
-5. Offer check_availability for a specific date
+`render_experience_cards` is the only tool that displays visual experience cards. Call it once for every result set you want shown, immediately after any discovery tool returns. Pass only the stable `t_` product IDs (never full rows), set `render_context.intent_summary` to what the user asked for (it becomes the carousel heading), and do not also re-list the same experiences as text.
 
-Always use `format: "json"` when processing data. Use `format: "text"` for direct display.
+## Using agent intelligence metadata
+
+Every search response includes metadata keys designed for you. Use them to give better answers:
+
+### `_best_picks`
+Auto-curated top 3 recommendations with reasoning. Lead with these when the user wants suggestions.
+- `best_value`: highest rating/price ratio
+- `highest_rated`: top-rated with significant reviews
+- `most_popular`: most reviewed (social proof)
+
+### `_price_tiers`
+Budget/mid-range/premium grouping. Use this to ask "do you have a budget in mind?" or present options by price bracket.
+
+### `_group_summary`
+Tag-based category breakdown (e.g. "8 Cruise, 6 GuidedTour, 5 Dining"). Use to say "I found a mix of cruises, guided tours, and dining experiences."
+
+### `_conversation_starters`
+Pre-built prompts referencing actual products. Use these to drive the conversation forward naturally.
+
+### `_available_filters`
+12 filter fields including tags, audience, price_range, duration_range, wheelchair_accessible, free_cancellation_count. Use to suggest narrowing: "Want me to filter to wheelchair-accessible options only?"
+
+### `_related_searches` / `_next_step`
+Follow-up suggestions and the recommended next action. Use when the user might want to explore adjacent categories or to move toward a booking.
+
+### On details responses
+- `_booking_urgency`: urgency signals like "Available TODAY", "Free cancellation", review counts. Surface these honestly; never invent urgency.
+- `_cross_sell`: natural pairings to offer after the main pick.
+- `_accessibility`: step-free access, age suitability, and similar constraints — check before recommending to families or users who mention access needs.
+- `_intent_token`: pass through where a tool asks for it; it links the discovery to the booking for quality tracking.
+
+## Conversation patterns
+
+### Discovery flow
+1. Start with `search_experiences`, `recommend_experiences`, or `search_by_mood`
+2. Present `_best_picks` as your top recommendations and render cards once
+3. Mention `_price_tiers` if the user hasn't specified a budget
+4. Use `_conversation_starters` to keep the dialogue flowing
+5. When the user shows interest, call `get_experience_details` for full info
+6. Offer `get_availability` (live dates/times/prices) or `check_availability` for a specific date + booking link
+
+### Comparison flow
+1. When the user is deciding between options, use `compare_experiences`
+2. Highlight the winner callouts (best_value, highest_rated, etc.)
+3. Call out key differences: price, duration, reviews, cancellation policy
+
+### Family planning flow
+1. Use `get_family_day` with kids' ages for age-aware recommendations
+2. The tool clusters geographically to reduce travel
+3. Includes morning, lunch, afternoon, and evening segments
+
+## Best practices
+
+- Always use `format: "json"` for structured data you'll process
+- Use `format: "text"` when you want to display results directly
+- The `sort: "best_value"` option is excellent for budget-conscious users
+- Combine `tags` and `audience` filters for precision (e.g. tags: "Museum", audience: "Family")
+- For wheelchair access, use `wheelchair_accessible: true`
+- For free cancellation, use `free_cancellation: true`
+- Pass `language` parameter for localised booking URLs (e.g. "de", "ja", "pt-br")
+- When the user mentions a specific experience by name, use `search_experiences` with `query` parameter to find it, then `get_experience_details` for full info
+- Present everything as tickadoo; never name an underlying supplier
+- If a result you surfaced turns out stale, unbookable, or misleading at click time, call `report_quality_signal` with the `request_id` from the original response — it closes the feedback loop
+
+## Coverage
+
+- 13,090+ bookable products
+- 700+ cities worldwide
+- 40+ languages for booking URLs
+- No API key required
+- All tools are read-only (no booking happens through the MCP, just discovery and deep links)

--- a/skills/tonight-and-last-minute/SKILL.md
+++ b/skills/tonight-and-last-minute/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: tonight-and-last-minute
+description: Find and book something to do tonight or in the next few hours with tickadoo — time-sensitive experiences sorted soonest-first, with live availability. Use when a user wants "what's on tonight", "something to do right now", last-minute plans, or same-day tickets in a specific city. Covers 700+ cities and 13,090+ bookable products.
+---
+
+# Tonight & last-minute with tickadoo
+
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user wants to do something NOW or tonight. This is a time-sensitive, high-intent moment: be fast, lead with what starts soonest, and always confirm live availability before promising anything — same-day inventory moves quickly.
+
+## When to use this
+
+"What's on tonight in Berlin", "anything to do right now near me", "last-minute tickets for this evening", "we've got a free evening in New York — what's available". If they're planning ahead (a future date, a multi-day trip), use the plan-a-trip / discovery skills instead.
+
+## The workflow (tool chain)
+
+1. **Pull time-sensitive options** — pick by horizon:
+   - `whats_on_tonight(city)` — bookable tonight, sorted soonest-first, already-started events filtered out. Each row has `start_time`, `countdown_text`, `venue`, and a short urgency hint.
+   - `get_last_minute(city, hours?)` — starting within the next few hours, with `start_time`, `countdown_text`, and `seats_remaining` hints.
+2. **Narrow to a pick** — if they react to one, `get_experience_details(product_id or slug)` for the fuller product + venue + location, but keep it quick — time is the constraint.
+3. **Book NOW** — `check_availability(slug, date: today, party_size)` for the same-day booking link, or `get_availability(product_id or slug, city_slug)` for live times/prices/remaining spaces. This is the critical step: never tell the user something is bookable tonight without a live check, because same-day availability is exactly what goes stale.
+4. **Nearby alternative** — if the first pick just sold out or started, `get_related_experiences(product_id, context: nearby|similar)` for the fastest fallback.
+
+## Show the results as cards
+
+After `whats_on_tonight` / `get_last_minute` returns a set, call `render_experience_cards(experience_ids, render_context)` once — pass only the stable `t_` IDs, set `render_context.intent_summary` ("tonight in <city>"). The cards carry the countdown/urgency visually, so don't also re-list them as text.
+
+## Read the agent-intelligence metadata
+
+- **_booking_urgency** — this is the star of this flow: surface "starts in 2h", "few seats left", "free cancellation" honestly and specifically. Never invent urgency.
+- **_best_picks** — lead with the soonest strong option, not the generically most_popular one.
+- **_next_step** / **_conversation_starters** — drive straight toward the booking link.
+
+## Conversation flow
+
+`whats_on_tonight` (or `get_last_minute`) → lead with the soonest 2-3 with their countdowns → the moment they pick one, check live availability for tonight and the party size → hand over the booking link → render cards once. Bias toward speed and honesty over breadth.
+
+## Etiquette
+
+- `format: "json"` when processing data; `format: "text"` for direct display.
+- Present everything as tickadoo — never name the underlying supplier.
+- Do NOT overstate availability. If the live check comes back sold out or past start time, say so and offer the nearest alternative.
+- Stale same-day availability is the most common failure here — if what you showed is gone or wrong at click time, send `report_quality_signal(request_id, ...)` with the `request_id` from the earlier call so tickadoo can tighten the feed.


### PR DESCRIPTION
## Context

OpenAI launched the **Plugin Directory** (replacing the App Directory). A plugin = your MCP server **plus optional Skills** — "reusable instructions that help ChatGPT use your app more effectively for complex workflows," managed in the OpenAI Platform Dashboard. tickadoo's MCP + Apps-SDK widget were auto-converted to a plugin (no action needed to stay live).

## Readiness audit

- **MCP / plugin: strong.** Live remote at `mcp.tickadoo.com/mcp`, 23 tools with excellent ChatGPT-oriented "Use this when…" descriptions (even explicit ChatGPT-vs-other-client routing), `render_experience_cards` on the OpenAI Apps SDK widget surface, and registry presence (server.json / smithery / glama / .claude-plugin).
- **Skills: the gap.** The repo shipped **one** generic discovery skill, stale in both copies (`skills/` said "15 tools"; `.claude/skills/` had drifted separately). The Plugin Directory rewards skills for **complex, multi-tool workflows**.

## What this PR does

**1. Six workflow skills**, each grounded in the live 23-tool `server.json`:

| Skill | Flow it teaches |
|---|---|
| `plan-a-trip` | `get_city_guide` → search/recommend/mood/`get_hidden_gems` → `plan_itinerary` → details → availability → cards |
| `family-day-out` | `get_family_day` (age-aware, walking-distance) → details/accessibility → availability → cards |
| `tonight-and-last-minute` | `whats_on_tonight`/`get_last_minute` → **live** availability → booking link → cards |
| `date-night` | `get_date_night` arc (pre-dinner → dinner area → show → post-show, est. total) → availability for 2 |
| `compare-before-you-book` | resolve slugs → `compare_experiences` per-axis winners → one clear recommendation → availability |
| `near-a-landmark` | `search_local_experiences` place hints, exact-vs-centre-fallback honesty → nearby pairing |

Each teaches: when ChatGPT should reach for it, the exact tool order, reading the agent-intelligence metadata (`_best_picks` / `_booking_urgency` / `_next_step` / `_price_tiers` / `_accessibility`), `render_experience_cards` discipline (once per set, `t_` ids only, no text re-list), honest urgency/availability, tickadoo-as-brand, and the `report_quality_signal` loop.

**2. Refreshed the stale `tickadoo-experiences` discovery skill** — rewritten once against the live server.json (full 23-tool table incl. `search_local_experiences` routing, `get_availability` vs `check_availability`, cards + quality-signal sections, details-side metadata) and **synced to both copies** (`skills/` + `.claude/skills/`), with frontmatter name now matching the folder. It cross-references the six workflow siblings.

**Validated:** frontmatter `name` == folder for all 7 skills; every tool reference in every skill resolves against `server.json`'s 23 tools.

## Notes

- **Format caveat:** authored in the repo's existing `SKILL.md` convention (portable content). The exact OpenAI upload wrapper should be confirmed in the OpenAI Platform Dashboard — the actual submission is a dashboard step (needs Francis's login), not something this repo deploys.

Drafts for review — happy to adjust tone or coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkiCXKJmCEHh6oQrLP68RD