### PR TITLE
skills: Plugin Directory set — web session's 7 skills + all Codex review fixes

### DIFF
--- a/skills/compare-before-you-book/SKILL.md
+++ b/skills/compare-before-you-book/SKILL.md
@@ -1,42 +1,35 @@
 ---
 name: compare-before-you-book
-description: Compare 2-5 specific tickadoo experiences side by side before booking — a real comparison table with per-axis winners (value, rating, popularity, family-fit), then live availability on the choice. Use when a user is deciding between named options, asks "which is better", "X or Y?", or wants help choosing between shows, tours, or attractions. Covers 700+ cities and 13,090+ bookable products.
+description: Compare 2-5 already-known tickadoo experiences side by side before booking, then check the preferred option. Use when the user's main task is choosing between specific named or previously shown products, including for a family, date, landmark or tonight. If a name does not identify a specific product, resolve or clarify it before comparing.
 ---
 
 # Compare before you book with tickadoo
 
-Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user is DECIDING, not discovering. The job is to turn "the London Eye or a river cruise?" into a grounded comparison with a clear recommendation and a bookable next step — not two paragraphs of generic pros and cons.
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user is DECIDING between specific options. Turn "X or Y?" into a grounded comparison with a clear recommendation.
 
 ## When to use this
 
-The user names (or has just been shown) specific options and wants help choosing: "which is better", "X or Y", "help me pick between these three", "is the expensive one worth it". If they haven't got candidates yet, run discovery first (`search_experiences` / `recommend_experiences`) and come back here once 2-5 contenders exist.
+Use a pair of clearly identified product names or previously shown cards. If either side is a category ("a river cruise"), run discovery first and obtain a specific contender before comparison.
 
 ## The workflow (tool chain)
 
-1. **Resolve the contenders to slugs** — `compare_experiences` takes slugs. If the user named products in prose, find each with `search_experiences(city, query: "<name>")` and take the slug from the result. If they're choosing from a set you just showed, you already have the slugs.
-2. **Compare** — `compare_experiences(slugs)` with 2-5 slugs. It returns a comparison table plus per-axis winners: value, rating, popularity, family-fit. This is the backbone; don't hand-write a comparison you could get from it.
-3. **Present the decision** — lead with the per-axis winners, then the differences that actually decide it: price, duration, rating vs review volume, cancellation policy. Map the winner to what the USER said they care about (budget → value winner; with kids → family-fit winner; once-in-a-lifetime → rating winner). Make one clear recommendation and say why.
-4. **Thin field?** — if the set feels weak, `get_related_experiences(product_id, context: similar)` on the strongest contender to add one better-fitting alternative, then re-compare.
-5. **Close the loop** — `get_experience_details(slug)` on the chosen one for the full picture, then `check_availability(slug, date, party_size)` for the booking link, or `get_availability(...)` for live dates/times/prices. A comparison that ends without a bookable winner is homework, not help.
+1. **Resolve 2-5 specific contenders** — search each prose name with `search_experiences(city, query)`. If a search returns several plausible products or ticket variants, show the distinctions and ask the user to choose. Never take the first slug silently. If the contenders came from a prior result set, reuse those exact slugs.
+2. **Compare** — `compare_experiences(slugs)` with 2-5 slugs. It returns a comparison table plus documented per-axis winners (value, rating, popularity, family-fit) — echo those, don't bury them.
+3. **Check before recommending** — if accessibility, cancellation terms or a fixed date could change the decision, fetch `get_experience_details` for both finalists and live-check both (`get_availability` with the date and party size, fresh when supported) BEFORE making the final recommendation. The eventual winner may be unavailable while the runner-up is bookable.
+4. **Recommend and close** — one clear recommendation tied to the user's stated priority, then `check_availability(slug, date, party_size)` only when the user wants the date-specific booking link.
+5. **Weak field?** — run `recommend_experiences` with the city and the user's priorities, or `search_experiences` with a precise query, to resolve one new specific contender, then compare again. Do not call `get_related_experiences` from ChatGPT.
 
-## Show the results as cards
+## Show results as cards
 
-When you show the contenders (or the winner + runner-up), call `render_experience_cards(experience_ids, render_context)` once — stable `t_` IDs only, `render_context.intent_summary` like "comparing Thames cruises for Saturday". Don't re-list the same products as text.
+Do not pass `compare_experiences` output directly to `render_experience_cards`. Render contenders only when their `t_` IDs came from a renderer-supported discovery result set (e.g. the resolver `search_experiences` calls), and render that set immediately, once, with a required `render_type` from the callable schema. Use `render_type: "comparison"` only when the callable schema permits it. Do not re-list rendered products in text.
 
-## Read the agent-intelligence metadata
+## Optional metadata
 
-- The per-axis **winners** from `compare_experiences` are the headline — echo them, don't bury them.
-- **_booking_urgency** (on details) can break a tie honestly: "both are great; this one has availability today with free cancellation".
-- **_price_tiers** — frame the price gap in tiers, not just absolute numbers.
-- **_accessibility** — if anyone in the party has access needs, check it on the finalists before recommending.
-
-## Conversation flow
-
-Confirm what matters to them (budget? kids? date fixed?) → resolve slugs → `compare_experiences` → per-axis winners + the 2-3 deciding differences → one clear recommendation tied to their stated priority → availability check on the winner → booking link → render cards once.
+Use fields documented by the selected tool and actually present in its response. The per-axis winners from `compare_experiences` are documented; optional underscore-prefixed metadata is not guaranteed — never assume it exists or treat it as a live check.
 
 ## Etiquette
 
-- `format: "json"` when processing data; `format: "text"` for direct display.
-- Present everything as tickadoo — never name the underlying supplier.
-- Be honest when it's genuinely close: say so, and let the availability check or cancellation policy settle it.
-- If comparison data is stale or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.
+- Present everything as tickadoo. Never name, infer or expose an upstream inventory supplier. Preserve material price, accessibility and cancellation facts.
+- Be honest when it's genuinely close; let the availability check or cancellation policy settle it. Never add time or sales pressure.
+- If the user asks to continue, provide the tickadoo link and make clear any purchase completes outside ChatGPT.
+- If the user reports stale or misleading comparison data, offer to send feedback; only after they agree, call `report_quality_signal` with the originating `request_id`, the required `signal_type` and no personal data in notes (a write action).

--- a/skills/date-night/SKILL.md
+++ b/skills/date-night/SKILL.md
@@ -1,45 +1,34 @@
 ---
 name: date-night
-description: Plan an evening for two in one city with tickadoo — a pre-dinner activity, dinner-area suggestion, evening show, post-show tip, and estimated total cost, all bookable. Use when a user wants a date night, a romantic evening, an anniversary plan, or "a nice night out for two" in a specific city. Covers 700+ cities and 13,090+ bookable products.
+description: Build one coherent evening for two in a single city with tickadoo, centred on bookable experiences plus dinner-area and post-show suggestions. Use for a date night, romantic evening or anniversary plan. Do not use for a multi-day romantic trip or a request for only the next available event tonight.
 ---
 
 # Date night with tickadoo
 
-Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) to plan a real, bookable evening for two — a coherent arc from pre-dinner to post-show, not a list of ten unconnected "romantic things".
+Build a coherent evening for two with the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) — an arc from pre-dinner to post-show, not ten unconnected "romantic things".
 
 ## When to use this
 
-The user wants an evening plan for a couple: "date night in Paris", "anniversary evening in London", "surprise my partner in Vienna on Saturday", "a nice night out for the two of us". If they want a full multi-day plan use `plan-a-trip`; if they just want whatever starts soonest tonight, use `tonight-and-last-minute`.
+The user wants an evening plan for a couple: "date night in Paris", "anniversary evening in London", "a nice night out for the two of us". For a multi-day plan use `plan-a-trip`; if they just want whatever starts soonest tonight, use `tonight-and-last-minute`.
 
 ## The workflow (tool chain)
 
-1. **Build the evening** — `get_date_night(city)` is the primary tool. It returns a pre-dinner activity, a dinner-area suggestion, an evening show, a post-show tip, and an estimated total cost, and it already filters out family-rated and high-physical-level venues. Do not hand-assemble an evening you could get from this tool.
-2. **Tune the vibe** — if they want alternatives for a slot:
-   - `search_by_mood(city, mood: "romantic")` for more couple-fit options.
-   - `whats_on_tonight(city)` if the date is TONIGHT, so the show slot is grounded in what actually starts this evening.
-   - `get_hidden_gems(city)` when they want something less obvious than the bestseller show.
-3. **Check the pick** — `get_experience_details(product_id or slug)` for the fuller product, venue, and location before committing the evening to it.
-4. **Make it bookable** — `check_availability(slug, date, party_size: 2)` for the date-specific booking link, or `get_availability(product_id or slug, city_slug)` for live times/prices/spaces. An anniversary plan that turns out sold-out is worse than no plan: always check before presenting the evening as settled.
-5. **Round it out** — `get_related_experiences(product_id, context: after|nearby)` for a post-show drink-adjacent idea near the venue.
+1. **Build the evening** — call `get_date_night` with `city` and, when known, `date` and the supported `budget` band (low/medium/high). It returns the evening structure, but the dinner area and post-show tip are suggestions rather than bookable products. Live-check each selected bookable experience before presenting the evening as settled.
+2. **Tune the vibe** — `search_by_mood(city, mood: "romantic")` for alternatives; `whats_on_tonight(city)` if the date is TONIGHT; `get_hidden_gems(city)` for something less obvious.
+3. **Nearby extras** — if the user wants another experience near the selected venue, call `search_local_experiences` with that venue or neighbourhood as the place hint. Do not call `get_related_experiences` from ChatGPT.
+4. **Check every bookable slot** — the evening can include a pre-dinner experience AND a show. For each selected bookable: `get_experience_details`, then `get_availability` for two on the date (fresh check when the schema supports it), then `check_availability(slug, date, party_size: 2)` only when the user wants the date-specific booking link. An anniversary plan that turns out sold out is worse than no plan.
 
-## Show the results as cards
+## Show results as cards
 
-After any discovery step returns a set you want shown, call `render_experience_cards(experience_ids, render_context)` once for that set — stable `t_` IDs only, `render_context.intent_summary` like "date night in Paris, Saturday". Don't re-list the same options as text.
+When a renderer-supported set will be shown (`get_date_night`, `search_by_mood`, `whats_on_tonight`, `get_hidden_gems`, `search_local_experiences` results), immediately call `render_experience_cards` exactly once for that set: stable `t_` IDs only, a required `render_type` from the callable schema, optionally `render_context.intent_summary` ("date night in Paris, Saturday"). Explain only the non-product arc (dinner area, estimated total) in text — do not re-list the rendered products.
 
-## Read the agent-intelligence metadata
+## Optional metadata
 
-- **_best_picks** — for couples, highest_rated usually beats most_popular; lead with it.
-- **_booking_urgency** — "few seats left" on a show matters double on a fixed date; surface it honestly.
-- **_price_tiers** — the estimated total from `get_date_night` plus tiers lets you ask "want to keep the evening under X?".
-- **_cross_sell** / **_next_step** — use for the post-show suggestion and to move to booking.
-
-## Conversation flow
-
-Confirm city + date (and any budget or occasion) → `get_date_night` → present the arc (pre-dinner → dinner area → show → post-show) with the estimated total → swap slots via mood/tonight/hidden-gems if asked → check availability for 2 on the date → hand over the booking link → render cards once. Keep the venues close together; a date night should not involve a metro sprint between slots.
+Use fields documented by the selected tool and actually present in its response. Optional underscore-prefixed helper metadata may inform the answer when returned, but never assume it exists, never invent a value and never treat it as a live availability check.
 
 ## Etiquette
 
-- `format: "json"` when processing data; `format: "text"` for direct display.
-- Present everything as tickadoo — never name the underlying supplier.
-- Respect the occasion: if they say anniversary/proposal, bias to highest_rated and confirmed availability over cheapest.
-- If a suggestion is stale or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.
+- Present everything as tickadoo. Never name, infer or expose an upstream inventory supplier. Preserve material venue, price, accessibility and cancellation facts.
+- Respect the occasion: for an anniversary or proposal, bias to confirmed availability over cheapest.
+- State only facts returned by the latest relevant check. Never add time or sales pressure. If the user asks to continue, provide the tickadoo link and make clear any purchase completes outside ChatGPT.
+- If the user reports a stale or misleading result, offer to send feedback; only after they agree, call `report_quality_signal` with the originating `request_id`, the required `signal_type` and no personal data in notes (a write action).

--- a/skills/family-day-out/SKILL.md
+++ b/skills/family-day-out/SKILL.md
@@ -1,44 +1,36 @@
 ---
 name: family-day-out
-description: Plan a full family day out in one city with tickadoo — age-aware, walking-distance-clustered activities a family can actually book. Use when a user is travelling or out with kids and wants "something to do with the children", a family day plan, or kid-friendly experiences in a specific city. Covers 700+ cities and 13,090+ bookable products.
+description: Build one coherent full or substantial family day in a single city with tickadoo, using the children's ages and geographically clustered activities. Use when the requested output is a family day plan. Do not use merely because children are mentioned. For a multi-day trip, one immediate activity, a named-option comparison or a place-led search, use the matching primary workflow and retain the family constraints.
 ---
 
 # Family day out with tickadoo
 
-Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) to plan a real, bookable day for a family in ONE city — matched to the kids' ages and clustered so nobody is dragging tired children across town.
+Build a real family day in ONE city with the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) — matched to the kids' ages and clustered so nobody drags tired children across town.
 
 ## When to use this
 
-The user mentions children / a family and wants a plan or ideas for a day: "what can we do in Amsterdam with a 5 and 8 year old", "family day out in London", "somewhere to take the kids this afternoon in Rome". If they want an adults' evening, use the date-night / tonight skills instead.
+Use this skill when the user wants a full or substantial single-day family plan in one city. If they want only one activity this afternoon or tonight, use general discovery or `tonight-and-last-minute` while retaining the children's ages as constraints.
 
 ## The workflow (tool chain)
 
-1. **Build the day** — `get_family_day(city, kids_ages, budget?)` is the primary tool. It returns a morning activity, a lunch-area suggestion, an afternoon attraction, and an optional evening stop, using age-aware filters and clustering venues by walking distance. Always pass `kids_ages` when you know them — it changes the picks materially.
-2. **Widen if asked** — if they want more options than the single plan:
-   - `search_experiences(city, tags: family/kids, sort?)` for a broader family list.
-   - `search_by_mood(city, mood: "family fun")` for a vibe-led pull.
-3. **Enrich the picks** — `get_experience_details(product_id or slug)` for the fuller product + location + any age restrictions/accessibility fields before you commit the family to it.
-4. **Make it bookable** — `check_availability(slug, date, party_size)` with the full party (count the kids) for a date + booking link, or `get_availability(product_id or slug, city_slug)` for the live dates/times/prices/spaces. Never say "you can book this" without checking.
-5. **Logistics** — `get_travel_tips(city, topic: "transport")` for getting around with kids; `get_transfer_info(city, from_type, to_lat, to_lng)` if they're arriving from an airport/station/port to their hotel.
+1. **Build the day** — call `get_family_day` with `city` and, when known, `kids_ages`, `date` and `budget`. Always pass the ages when known — they change the picks materially. Treat any activity as proposed until availability has been checked for the full party.
+2. **Widen if asked** — `search_experiences(city, tags: ["family"])` for a broader family list (tags is an array; `family` is the canonical tag), or `search_by_mood(city, mood: "family_fun")` for a vibe-led pull.
+3. **Enrich the picks** — `get_experience_details(product_id or slug)` for age restrictions and accessibility fields before committing the family to anything.
+4. **Check every selected product** — a family day has multiple bookable products (morning and afternoon at least). For each selected one: `get_availability` with the date range and the FULL party size (count the kids), requesting a fresh check when the schema supports it; then `check_availability(slug, date, party_size)` only when the user wants the date-specific booking link. Label unchecked slots as suggestions.
+5. **Logistics** — `get_travel_tips(city, topic: "transport")` for getting around with kids. Use `get_transfer_info` only when an approved client supplies destination coordinates through a controlled location channel and the city is supported; never ask the user for, infer or guess precise coordinates in chat.
 
-## Show the results as cards
+## Show results as cards
 
-After any discovery step returns a set to show, call `render_experience_cards(experience_ids, render_context)` once for that set — pass only the stable `t_` IDs, set `render_context.intent_summary` (city, "family with kids aged X"). Don't re-list the same experiences as text.
+When a renderer-supported set will be shown (`get_family_day`, `search_experiences`, `search_by_mood` results), immediately call `render_experience_cards` exactly once for that set: only its stable `t_` IDs in `experience_ids`, a required `render_type` allowed by the callable schema (carousel works well here), optionally `render_context.intent_summary`. Do not reproduce the same products in surrounding text — explain the schedule shape instead.
 
-## Read the agent-intelligence metadata
+## Optional metadata
 
-- **_best_picks** — lead with these; for families, highest_rated and best_value usually matter more than most_popular.
-- **_accessibility** (on details) — check step-free access, stroller/pram notes, and age suitability before recommending.
-- **_booking_urgency** — surface genuine "available today / free cancellation" honestly.
-- **_price_tiers** / **_conversation_starters** / **_next_step** — use to check the budget and move toward booking.
-
-## Conversation flow
-
-Ask the kids' ages if not given (it changes everything) → `get_family_day` → present the morning/lunch/afternoon/evening shape with `_best_picks` first → confirm ages/accessibility via details → offer to check availability for the party size on the day → render cards once.
+Use fields documented by the selected tool and actually present in its response (accessibility fields on details matter most here). Optional underscore-prefixed helper metadata may inform the answer when returned, but never assume it exists, never invent a value and never treat it as a live availability check.
 
 ## Etiquette
 
-- `format: "json"` when processing data; `format: "text"` for direct display.
-- Present everything as tickadoo — never name the underlying supplier.
-- Keep the day walkable and age-appropriate; don't stack two big paid attractions if the budget signal is tight.
-- If a suggestion is stale or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.
+- Present discovery and the booking route as tickadoo. Never name, infer or expose an upstream inventory supplier. Preserve material venue, price, accessibility, cancellation and fulfilment facts returned by tickadoo.
+- Keep the day walkable and age-appropriate; respect a tight budget signal.
+- State only facts returned by the latest relevant check. Never add time or sales pressure. If the user asks to continue, provide the tickadoo link and make clear any purchase is completed outside ChatGPT.
+- If the user reports a stale, unbookable or misleading result, offer to send feedback; only after they agree, call `report_quality_signal` with the originating `request_id`, the required `signal_type` and no personal data in notes (a write action).
+- Frame this as a planning tool for the accompanying adults.

--- a/skills/near-a-landmark/SKILL.md
+++ b/skills/near-a-landmark/SKILL.md
@@ -1,42 +1,35 @@
 ---
 name: near-a-landmark
-description: Find bookable experiences near a landmark, neighbourhood, or area with tickadoo — "near the Louvre", "in Trastevere", "around Times Square" — without needing coordinates. Use when a user anchors their ask to a place inside a city rather than the city as a whole, including "walking distance from my hotel/venue". Covers 700+ cities and 13,090+ bookable products.
+description: Find experiences near a named landmark, neighbourhood, hotel or venue with tickadoo, without asking for coordinates. Use when proximity is the main constraint and no higher-priority comparison, multi-day, coherent family-day, coherent date-night or immediate-time workflow applies. If the place is unnamed, ask for it.
 ---
 
 # Near a landmark with tickadoo
 
-Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user's ask is anchored to a PLACE inside a city, not the city itself. "Things to do near the Louvre" is a different question from "things to do in Paris" — answer it with place-anchored search, not a city-wide list they have to filter themselves.
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the ask is anchored to a PLACE inside a city. "Things to do near the Louvre" is a different question from "things to do in Paris".
 
 ## When to use this
 
-The user mentions a landmark, neighbourhood, square, venue, or area: "near the Louvre", "in Trastevere", "around Times Square", "walking distance from St Paul's Cathedral", "we're staying by the Sagrada Familia — what's close?". If they mean the whole city, use `search_experiences` (or the discovery skills) instead.
+The user names a landmark, neighbourhood, square, venue or area: "near the Louvre", "in Trastevere", "around Times Square". If the place is unnamed ("walking distance from my hotel"), ask which hotel or area they mean — never guess. If they mean the whole city, use city-wide discovery instead.
 
 ## The workflow (tool chain)
 
-1. **Place-anchored search** — `search_local_experiences(<place hint>)` is the primary tool. It takes the coarse place phrase directly (no coordinates needed) and matches first by exact venue/neighbourhood, then falls back to the city centre. Do NOT use it for general city-wide search; that's `search_experiences`.
-   - `find_nearby_experiences(latitude, longitude, radius_km)` exists for clients that supply exact coordinates; in ChatGPT, prefer `search_local_experiences` — you almost never have real coordinates, and guessing them is worse than passing the place hint.
-2. **Tell them what "near" meant** — if the results came from the city-centre fallback rather than an exact venue/neighbourhood match, say so ("I couldn't anchor to that exact spot, so these are central-Paris options") instead of implying everything is next door.
-3. **Enrich the picks** — `get_experience_details(product_id or slug)` for the fuller product and its actual location, so you can sanity-check the distance story before promising "5 minutes' walk".
-4. **Make it bookable** — `get_availability(product_id or slug, city_slug)` for live dates/times/prices/spaces, or `check_availability(slug, date, party_size)` when they name a date.
-5. **Chain the area** — `get_related_experiences(product_id, context: nearby)` to build a "while you're there" pair (the thing next door after the main sight); `get_travel_tips(city, topic: "transport")` if they ask how to get to/from the area.
+1. **Place-anchored search** — `search_local_experiences(place_hint, city?)` is the primary tool. It takes the coarse place phrase directly (no coordinates) and matches first by exact venue/neighbourhood, then falls back to the city centre. Do not use `find_nearby_experiences` from ChatGPT (it needs real coordinates), and never guess coordinates.
+2. **Say what "near" meant** — prefer exact venue or neighbourhood matches over city-centre fallback results, and say which you got ("I couldn't anchor to that exact spot, so these are central-Paris options"). Do not claim or rank by walking time unless returned location data supports it.
+3. **Enrich the picks** — `get_experience_details(product_id or slug)` for the actual location before making any proximity claim.
+4. **Check the pick** — `get_availability` for the selected product (date range, party size, fresh when supported), then `check_availability(slug, date, party_size)` only when the user wants the date-specific booking link.
+5. **"While you are there" pair** — run a new `search_local_experiences` call anchored to the selected venue or area. `get_travel_tips(city, topic: "transport")` if they ask how to get there.
 
-## Show the results as cards
+## Show results as cards
 
-After `search_local_experiences` returns a set, call `render_experience_cards(experience_ids, render_context)` once — stable `t_` IDs only, `render_context.intent_summary` like "near the Louvre this afternoon". Don't re-list the same experiences as text.
+When a `search_local_experiences` set will be shown, immediately call `render_experience_cards` exactly once for it: stable `t_` IDs only, a required `render_type` from the callable schema, optionally `render_context.intent_summary` ("near the Louvre this afternoon"). Do not re-list the same experiences in text.
 
-## Read the agent-intelligence metadata
+## Optional metadata
 
-- **_best_picks** — lead with them, but weigh proximity too: the point of this flow is location-fit, and a slightly lower-rated option genuinely at the landmark can beat a bestseller across town.
-- **_booking_urgency** — someone already standing near the landmark is a same-day booker; surface "available today" honestly.
-- **_group_summary** / **_related_searches** — narrate the area's mix ("around Trastevere it's mostly food tours and evening walks") and offer adjacent angles.
-
-## Conversation flow
-
-Take the place phrase as given → `search_local_experiences` → say whether the match was exact or centre-fallback → lead with `_best_picks` weighted by proximity → details on the pick to confirm the location → availability (often same-day) → booking link → render cards once → offer a `nearby` pairing.
+Use fields documented by the selected tool and actually present in its response. Optional underscore-prefixed helper metadata may inform the answer when returned, but never assume it exists, never invent a value and never treat it as a live availability check.
 
 ## Etiquette
 
-- `format: "json"` when processing data; `format: "text"` for direct display.
-- Present everything as tickadoo — never name the underlying supplier.
-- Never oversell proximity: check the details' location before claiming walking distance.
-- If a result is stale, mis-located, or wrong at click time, send `report_quality_signal(request_id, ...)` using the `request_id` from the earlier call.
+- Present everything as tickadoo. Never name, infer or expose an upstream inventory supplier.
+- Never oversell proximity: check the details' location before claiming distances.
+- State only facts returned by the latest relevant check. Never add time or sales pressure. If the user asks to continue, provide the tickadoo link and make clear any purchase completes outside ChatGPT.
+- If the user reports a stale, mis-located or misleading result, offer to send feedback; only after they agree, call `report_quality_signal` with the originating `request_id`, the required `signal_type` and no personal data in notes (a write action).

--- a/skills/plan-a-trip/SKILL.md
+++ b/skills/plan-a-trip/SKILL.md
@@ -1,49 +1,38 @@
 ---
 name: plan-a-trip
-description: Plan a multi-day trip for a single city with tickadoo — turn "what should I do in Rome for 3 days?" into a day-by-day, geographically-sensible plan of bookable experiences. Use when a user wants an itinerary, a multi-day plan, or help filling several days in one city with things to do. Covers 700+ cities and 13,090+ bookable products.
+description: Build a multi-day itinerary in one city with tickadoo. Use when the user wants activities arranged across two or more days. This is the primary workflow for a multi-day request even when the user also mentions children, romance or a neighbourhood. Retain those constraints. Do not use for one evening, one family day, immediate same-day options or choosing between named experiences.
 ---
 
 # Plan a trip with tickadoo
 
-Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) to build a real, bookable multi-day plan for ONE city, not a generic listicle. The whole point is that every suggestion can be checked for live availability and booked, so lean on the tools instead of prior knowledge.
+Build a real multi-day plan for ONE city with the tickadoo MCP tools (`mcp.tickadoo.com/mcp`), grounded in the catalogue rather than prior knowledge.
 
 ## When to use this
 
-The user wants to fill more than one time slot or more than one day in a single city: "3 days in Barcelona", "what should we do in Tokyo this weekend", "plan our London trip", "a Paris itinerary for a couple". If they only want one thing right now, or tonight, use the discovery / tonight skills instead.
+The user wants activities arranged across at least two days in one city, such as "three days in Barcelona", "plan our Tokyo weekend" or "a Paris itinerary from Monday to Thursday". If the request covers only one day or one time period, use the relevant discovery, family, date-night or tonight skill.
 
 ## The workflow (tool chain)
 
-1. **Orient** — `get_city_guide(city)` first. It returns highlights, dominant categories, price band, best-for audience hints, and seasonal notes. Use it to set expectations and to pick a sensible mix, and mention the seasonal note if relevant. If the city is ambiguous or misspelled, `list_cities(query)` to confirm the slug.
-2. **Gather candidates** — pull a pool to plan from:
-   - `search_experiences(city, category?, tags?, sort?)` for named interests ("museums", "food tours").
-   - `recommend_experiences(query)` when they describe what they want in prose ("relaxed, lots of history, not too touristy").
-   - `search_by_mood(city, mood)` for a vibe ("romantic", "foodie", "rainy day").
-   - `get_hidden_gems(city)` to add a local-favourite or two so the plan is not all bestsellers.
-3. **Build the plan** — `plan_itinerary(city, days, ...)`. It returns morning / afternoon / evening slots per day with geographic clustering, category diversity, and a running total cost. This is the backbone — do not hand-assemble a plan you could get from this tool.
-4. **Enrich the picks** — for each experience the user shows interest in, `get_experience_details(product_id or slug)` for the richer product, location, and booking fields.
-5. **Make it bookable** — `get_availability(product_id or slug, city_slug)` for live dates/times/prices/spaces, or `check_availability(slug, date, party_size)` when they name a date and party and want a booking link. Never assert something is available without checking.
-6. **Fill gaps / pair things** — `get_related_experiences(product_id, context: pair|after|nearby|similar)` to slot in a nearby lunch or an after-show idea.
+1. **Orient** — `get_city_guide(city)` for highlights, dominant categories, price band and seasonal notes. If the city is unclear or ambiguous, ask the user to clarify (use `list_cities` only to browse, optionally by country — it has no free-text query).
+2. **Build the backbone** — call `plan_itinerary` with `city` and `days`. When known, also pass the user's `interests`, `audience`, `budget` band and `pace` using the callable schema. It independently returns the day slots, geographic clustering, category mix and running cost.
+3. **Replace or widen only when needed** — use `search_experiences` for a named category, `recommend_experiences` for a natural-language preference, `search_by_mood` for a supported mood, or `get_hidden_gems` for one or two less-obvious options so the plan is not all bestsellers — only when the user asks to replace a slot or browse alternatives. Do not imply that an earlier candidate pool is consumed by `plan_itinerary`.
+4. **Enrich and check selected items** — fetch `get_experience_details` for experiences the user is considering, then follow the live-availability sequence for each selected slot.
 
-## Show the results as cards
+## Show results as cards
 
-After ANY discovery/search step returns a set you want to show, call `render_experience_cards(experience_ids, render_context)` exactly once for that set. Pass only the stable `t_` product IDs, and set `render_context.intent_summary` to what the user asked for (city, dates, audience) — it becomes the carousel heading. Do not also re-list those experiences as text.
+Only the renderer-supported search calls in this workflow (`search_experiences`, `recommend_experiences`, `search_by_mood`, `get_hidden_gems`) may feed `render_experience_cards`. Do not assume `get_city_guide` or `plan_itinerary` can be rendered. When such a set will be shown, immediately call `render_experience_cards` exactly once for it: only its stable `t_` IDs in `experience_ids`, a required `render_type` allowed by the callable schema, optionally `render_context.intent_summary`. Do not reproduce the same products in surrounding text. Present the itinerary itself as a plan, without duplicating any separately rendered search set.
 
-## Read the agent-intelligence metadata
+## Availability discipline (composite plan)
 
-Every search response carries metadata — use it, don't ignore it:
+Treat the returned plan as proposed until every selected bookable slot has been checked for the user's date and party size: `get_availability` per slot (product_id, or slug + city_slug; pass the date range and party size; request a fresh check when the schema supports it), then `check_availability(slug, date, party_size)` only when the user wants the date-specific booking link. If the user has not asked to check every slot, label unchecked slots as suggestions rather than confirmed bookable plans.
 
-- **_best_picks** — lead each day's options with these (best_value / highest_rated / most_popular).
-- **_price_tiers** — if budget matters, present by bracket or ask "what's your budget for the trip?".
-- **_group_summary** — narrate the mix ("I've balanced two big sights, a food tour, and a relaxed evening").
-- **_conversation_starters** / **_next_step** — use these to move the plan forward ("want me to lock in Tuesday's availability?").
-- **_booking_urgency** — surface genuine urgency (available today, free cancellation) honestly, never invented.
+## Optional metadata
 
-## Conversation flow
-
-City guide → gather a candidate pool → `plan_itinerary` → present day-by-day with `_best_picks` up front and a running cost → offer to check availability on the dates that matter → render cards once per set. Keep geography tight (don't zig-zag across the city), keep category variety, and respect the budget signal.
+Use fields documented by the selected tool and actually present in its response. Optional underscore-prefixed helper metadata may inform the answer when returned, but never assume it exists, never invent a value and never treat it as a live availability check.
 
 ## Etiquette
 
-- Always `format: "json"` when you're processing data; `format: "text"` only for direct display.
-- Present everything as tickadoo — never name the underlying supplier.
-- If something you surfaced turns out stale or wrong at click time, send `report_quality_signal(request_id, ...)` with the `request_id` from the earlier call so tickadoo can fix it.
+- Present discovery and the booking route as tickadoo. Never name, infer or expose an upstream inventory supplier. Do not imply tickadoo operates the venue. Preserve material venue, price, accessibility, cancellation and fulfilment facts returned by tickadoo.
+- State only the exact time, inventory, availability or cancellation fact returned by the latest relevant tool. Never add time pressure or sales pressure.
+- If the user asks to continue, provide the tickadoo link and make clear that any purchase is completed outside ChatGPT.
+- If the user reports a surfaced result was stale, unbookable or misleading, offer to send feedback to tickadoo; only after they agree, call `report_quality_signal` with the originating `request_id`, the required `signal_type` and no personal data in notes (it is a write action).

--- a/skills/tickadoo-experiences/SKILL.md
+++ b/skills/tickadoo-experiences/SKILL.md
@@ -1,128 +1,70 @@
 ---
 name: tickadoo-experiences
-description: Discover and book theatre, tours, attractions, and events across 700+ cities using the tickadoo MCP server. Use this skill when the user asks about things to do, experiences, shows, events, tours, or activities in any city worldwide. Covers trip planning, availability checks, experience comparison, mood-based discovery, family day planning, and travel tips.
-license: MIT
+description: General tickadoo discovery and utility map for city-wide experience searches, named-experience lookup, mood-led ideas, weekly listings, city guides, travel tips and availability questions that do not match a specialist workflow. Do not use as the primary skill for a multi-day itinerary, a full family day, an immediate or same-day search, a coherent date night, a comparison of 2-5 known options or a landmark-anchored search. Use the matching tickadoo workflow skill.
 ---
 
-# tickadoo Experiences Skill
+# tickadoo Experiences (general map)
 
-This skill teaches you how to effectively use the tickadoo MCP server (mcp.tickadoo.com/mcp, 23 tools) to help users discover, compare, and book experiences worldwide. Sibling workflow skills cover the deep multi-tool flows end-to-end: `plan-a-trip`, `family-day-out`, `tonight-and-last-minute`, `date-night`, `compare-before-you-book`, `near-a-landmark` — prefer those when the user's request matches; use this skill as the general map.
+The general map for the tickadoo MCP server (`mcp.tickadoo.com/mcp`). Six specialist workflow skills own the deep flows — route to them first:
 
-## When to use this skill
+- Multi-day itinerary in one city → `plan-a-trip`
+- One coherent family day → `family-day-out`
+- Tonight / next few hours → `tonight-and-last-minute`
+- One coherent evening for two → `date-night`
+- Choosing between 2-5 known products → `compare-before-you-book`
+- Anchored to a named place inside a city → `near-a-landmark`
 
-Use the tickadoo MCP when a user:
-- Asks "what should I do in [city]?" or "things to do in [city]"
-- Wants to find shows, theatre, tours, attractions, or events
-- Needs to plan a trip or day out
-- Asks for availability or pricing on a specific experience
-- Wants to compare options side by side
-- Describes a mood or vibe ("something romantic", "rainy day activity")
-- Mentions a landmark or neighbourhood ("near the Louvre", "in Trastevere")
-- Asks for family-friendly recommendations
-- Needs travel tips or transfer info for a city
+Use this skill only when none of those is the primary shape of the request.
 
-## Tool selection guide
+## Tool selection map
 
 | User intent | Tool | Key parameters |
 |---|---|---|
-| General discovery | `search_experiences` | city, category, sort, tags, query |
-| Natural-language ask ("relaxed, historic, not touristy") | `recommend_experiences` | query |
-| Mood/vibe based | `search_by_mood` | city, mood (romantic, adventurous, foodie, etc.) |
-| Near a landmark/neighbourhood (no coordinates) | `search_local_experiences` | place hint ("near the Louvre") |
-| Exact coordinates (non-ChatGPT clients only) | `find_nearby_experiences` | latitude, longitude, radius_km |
+| City-wide discovery | `search_experiences` | city, query, category, tags (array, e.g. `["family"]`), min_rating, max_price, limit |
+| Natural-language ask | `recommend_experiences` | query, city?, date?, pax? |
+| Mood/vibe based | `search_by_mood` | city, mood (enum, e.g. `family_fun`, `romantic`, `rainy_day`) |
+| Near a place (no coordinates) | `search_local_experiences` | place_hint, city?, radius_hint? |
 | Specific experience | `get_experience_details` | product_id or slug |
-| Live dates/times/prices/spaces | `get_availability` | product_id or slug, city_slug |
-| Date-specific check + booking link | `check_availability` | slug, date, party_size |
-| Compare options | `compare_experiences` | slugs (2-5) |
-| "Anything like this" / "what next" | `get_related_experiences` | product_id, context: pair\|after\|nearby\|similar |
+| Live dates/times/prices/spaces | `get_availability` | product_id or slug + city_slug, date_from/to, party_size, fresh |
+| Date-specific link (legacy interface) | `check_availability` | slug, date, party_size |
+| Compare 2-5 specific products | `compare_experiences` | slugs |
 | City overview | `get_city_guide` | city |
-| Tonight's options | `whats_on_tonight` | city |
-| This week | `get_whats_on_this_week` | city |
-| Last minute | `get_last_minute` | city, hours |
-| Multi-day plan | `plan_itinerary` | city, days |
-| Family planning | `get_family_day` | city, kids_ages, budget |
-| Evening for two | `get_date_night` | city |
-| Local favourites, not bestsellers | `get_hidden_gems` | city |
-| Travel advice | `get_travel_tips` | city, topic |
-| Airport transfer | `get_transfer_info` | city, from_type, to_latitude, to_longitude |
-| Browse cities | `list_cities` | query, limit |
-| Show visual cards | `render_experience_cards` | experience_ids (t_ ids), render_context |
-| Report a bad result | `report_quality_signal` | request_id, signal |
+| Tonight / next hours / this week | `whats_on_tonight` / `get_last_minute` / `get_whats_on_this_week` | city |
+| Multi-day plan | `plan_itinerary` | city, days, interests?, audience?, budget?, pace? |
+| Family day / evening for two | `get_family_day` / `get_date_night` | city (+ kids_ages, date, budget where known) |
+| Less-popular, highly rated options | `get_hidden_gems` | city |
+| Travel advice | `get_travel_tips` | city, topic? |
+| Browse cities | `list_cities` | country?, limit? (no free-text query — if the city is unclear, ask the user) |
+| Show visual cards | `render_experience_cards` | experience_ids (t_ IDs), required render_type, optional render_context.intent_summary |
+| Report an agreed quality issue | `report_quality_signal` | request_id, signal_type, optional non-personal notes |
 
-ChatGPT note: prefer `search_local_experiences` (coarse place hints) over `find_nearby_experiences` (exact lat/lng) — the latter is for clients that supply real coordinates.
+Non-ChatGPT only (do not call from ChatGPT): `find_nearby_experiences` (needs real coordinates), `get_related_experiences` (reserved for a non-ChatGPT widget/client).
 
-## Showing results as cards
+`get_transfer_info` requires precise destination coordinates: use it only when a supported client supplies them through an approved location channel and the city is supported. Never ask the user for, infer, or guess coordinates in chat; prefer `get_travel_tips(city, topic: "transport")`.
 
-`render_experience_cards` is the only tool that displays visual experience cards. Call it once for every result set you want shown, immediately after any discovery tool returns. Pass only the stable `t_` product IDs (never full rows), set `render_context.intent_summary` to what the user asked for (it becomes the carousel heading), and do not also re-list the same experiences as text.
+## The universal card rule
 
-## Using agent intelligence metadata
+When a renderer-supported discovery tool (`search_experiences`, `whats_on_tonight`, `get_last_minute`, `get_whats_on_this_week`, `recommend_experiences`, `search_by_mood`, `get_hidden_gems`, `get_family_day`, `get_date_night`, `search_local_experiences`) returns a result set that will be shown, immediately call `render_experience_cards` exactly once for that set. Pass only its stable `t_` IDs in `experience_ids`, pass a required `render_type` allowed by the callable schema, and optionally `render_context.intent_summary`. Do not enumerate or reproduce the same products in surrounding text — add only non-duplicative synthesis, constraints, or a follow-up question. Do not render output from tools not on that list (e.g. `plan_itinerary`, `get_city_guide`, `compare_experiences`).
 
-Every search response includes metadata keys designed for you. Use them to give better answers:
+## The live-availability rule
 
-### `_best_picks`
-Auto-curated top 3 recommendations with reasoning. Lead with these when the user wants suggestions.
-- `best_value`: highest rating/price ratio
-- `highest_rated`: top-rated with significant reviews
-- `most_popular`: most reviewed (social proof)
+Treat discovery results, countdowns, remaining-seat hints and optional urgency metadata as preliminary. For each selected bookable experience, call `get_availability` using `product_id` when available, or `slug` plus `city_slug`. For a fixed-date or same-day claim, pass the relevant date range and party size and request a fresh check when the callable schema supports it. If the user wants a date-specific booking link, then call `check_availability` with the slug, the experience's local calendar date and party size. State only facts returned by the most recent relevant check.
 
-### `_price_tiers`
-Budget/mid-range/premium grouping. Use this to ask "do you have a budget in mind?" or present options by price bracket.
+## Optional metadata
 
-### `_group_summary`
-Tag-based category breakdown (e.g. "8 Cruise, 6 GuidedTour, 5 Dining"). Use to say "I found a mix of cruises, guided tours, and dining experiences."
+Use fields documented by the selected tool and actually present in its response. Optional underscore-prefixed helper metadata (`_best_picks`, `_price_tiers`, `_booking_urgency`, etc.) may inform the answer when returned, but never assume it exists, never invent a value and never treat it as a live availability check.
 
-### `_conversation_starters`
-Pre-built prompts referencing actual products. Use these to drive the conversation forward naturally.
+## Quality feedback (a write action)
 
-### `_available_filters`
-12 filter fields including tags, audience, price_range, duration_range, wheelchair_accessible, free_cancellation_count. Use to suggest narrowing: "Want me to filter to wheelchair-accessible options only?"
+If the user reports that a surfaced result was stale, unbookable or misleading, explain that you can send feedback to tickadoo. Only after the user agrees, call `report_quality_signal` with the originating `request_id`, the required `signal_type` and no personal data in notes. No purchase is completed through the MCP; discovery, planning, availability and rendering calls retrieve data or booking links, while `report_quality_signal` records feedback and is therefore a write action.
 
-### `_related_searches` / `_next_step`
-Follow-up suggestions and the recommended next action. Use when the user might want to explore adjacent categories or to move toward a booking.
+## Brand and conduct
 
-### On details responses
-- `_booking_urgency`: urgency signals like "Available TODAY", "Free cancellation", review counts. Surface these honestly; never invent urgency.
-- `_cross_sell`: natural pairings to offer after the main pick.
-- `_accessibility`: step-free access, age suitability, and similar constraints — check before recommending to families or users who mention access needs.
-- `_intent_token`: pass through where a tool asks for it; it links the discovery to the booking for quality tracking.
-
-## Conversation patterns
-
-### Discovery flow
-1. Start with `search_experiences`, `recommend_experiences`, or `search_by_mood`
-2. Present `_best_picks` as your top recommendations and render cards once
-3. Mention `_price_tiers` if the user hasn't specified a budget
-4. Use `_conversation_starters` to keep the dialogue flowing
-5. When the user shows interest, call `get_experience_details` for full info
-6. Offer `get_availability` (live dates/times/prices) or `check_availability` for a specific date + booking link
-
-### Comparison flow
-1. When the user is deciding between options, use `compare_experiences`
-2. Highlight the winner callouts (best_value, highest_rated, etc.)
-3. Call out key differences: price, duration, reviews, cancellation policy
-
-### Family planning flow
-1. Use `get_family_day` with kids' ages for age-aware recommendations
-2. The tool clusters geographically to reduce travel
-3. Includes morning, lunch, afternoon, and evening segments
-
-## Best practices
-
-- Always use `format: "json"` for structured data you'll process
-- Use `format: "text"` when you want to display results directly
-- The `sort: "best_value"` option is excellent for budget-conscious users
-- Combine `tags` and `audience` filters for precision (e.g. tags: "Museum", audience: "Family")
-- For wheelchair access, use `wheelchair_accessible: true`
-- For free cancellation, use `free_cancellation: true`
-- Pass `language` parameter for localised booking URLs (e.g. "de", "ja", "pt-br")
-- When the user mentions a specific experience by name, use `search_experiences` with `query` parameter to find it, then `get_experience_details` for full info
-- Present everything as tickadoo; never name an underlying supplier
-- If a result you surfaced turns out stale, unbookable, or misleading at click time, call `report_quality_signal` with the `request_id` from the original response — it closes the feedback loop
+- Present discovery and the booking route as tickadoo. Never name, infer or expose an upstream inventory supplier. Do not imply that tickadoo operates the venue or experience. Preserve material venue, price, accessibility, cancellation and fulfilment facts returned by tickadoo.
+- State only the exact time, inventory, availability or cancellation fact returned by the latest relevant tool. Review counts show popularity, not scarcity. Never add time pressure or sales pressure.
+- If the user asks to continue to booking, provide the tickadoo link and make clear that any purchase is completed outside ChatGPT.
+- When a tool exposes `format`, use `json` for processing. Pass `language` only when the callable schema exposes it; do not promise localised booking URLs unless the returned data provides one.
 
 ## Coverage
 
-- 13,090+ bookable products
-- 700+ cities worldwide
-- 40+ languages for booking URLs
-- No API key required
-- All tools are read-only (no booking happens through the MCP, just discovery and deep links)
+Coverage is determined by the current tickadoo catalogue and the cities returned by the MCP. Do not quote a city, product or language count unless it is present in the current submitted metadata.

--- a/skills/tonight-and-last-minute/SKILL.md
+++ b/skills/tonight-and-last-minute/SKILL.md
@@ -1,42 +1,34 @@
 ---
 name: tonight-and-last-minute
-description: Find and book something to do tonight or in the next few hours with tickadoo — time-sensitive experiences sorted soonest-first, with live availability. Use when a user wants "what's on tonight", "something to do right now", last-minute plans, or same-day tickets in a specific city. Covers 700+ cities and 13,090+ bookable products.
+description: Find experiences in a city tonight or within the next few hours with tickadoo, followed by a current availability check on the selected option. Use when immediacy is the deciding constraint. If the user explicitly asks for a coherent multi-stop date night or full family day, use that planning skill and perform same-day checks within it.
 ---
 
 # Tonight & last-minute with tickadoo
 
-Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user wants to do something NOW or tonight. This is a time-sensitive, high-intent moment: be fast, lead with what starts soonest, and always confirm live availability before promising anything — same-day inventory moves quickly.
+Use the tickadoo MCP tools (`mcp.tickadoo.com/mcp`) when the user wants to do something NOW or tonight. Be fast, lead with what starts soonest, and confirm current availability before stating anything is bookable — same-day inventory is exactly what goes stale.
 
 ## When to use this
 
-"What's on tonight in Berlin", "anything to do right now near me", "last-minute tickets for this evening", "we've got a free evening in New York — what's available". If they're planning ahead (a future date, a multi-day trip), use the plan-a-trip / discovery skills instead.
+"What's on tonight in Berlin", "anything to do right now", "last-minute tickets this evening". If they're planning ahead (a future date, a multi-day trip), use the planning skills instead.
 
 ## The workflow (tool chain)
 
-1. **Pull time-sensitive options** — pick by horizon:
-   - `whats_on_tonight(city)` — bookable tonight, sorted soonest-first, already-started events filtered out. Each row has `start_time`, `countdown_text`, `venue`, and a short urgency hint.
-   - `get_last_minute(city, hours?)` — starting within the next few hours, with `start_time`, `countdown_text`, and `seats_remaining` hints.
-2. **Narrow to a pick** — if they react to one, `get_experience_details(product_id or slug)` for the fuller product + venue + location, but keep it quick — time is the constraint.
-3. **Book NOW** — `check_availability(slug, date: today, party_size)` for the same-day booking link, or `get_availability(product_id or slug, city_slug)` for live times/prices/remaining spaces. This is the critical step: never tell the user something is bookable tonight without a live check, because same-day availability is exactly what goes stale.
-4. **Nearby alternative** — if the first pick just sold out or started, `get_related_experiences(product_id, context: nearby|similar)` for the fastest fallback.
+1. **Pull time-sensitive options** — by horizon: `whats_on_tonight(city)` for tonight, `get_last_minute(city, hours?)` for the next few hours. Use `start_time` and `countdown_text` when present in the response; do not assume they exist or invent them.
+2. **Narrow to a pick** — `get_experience_details(product_id or slug)` on the one they react to; keep it quick.
+3. **Live-check the pick** — `get_availability` for the selected product with the party size, requesting a fresh check when the callable schema supports it (this is the live supplier check; a countdown hint is not). Use the local calendar date contained in the selected result's `start_time` — do not derive "today" from the assistant's system timezone. Then `check_availability(slug, date, party_size)` only when the user wants the date-specific booking link.
+4. **Fallback** — if the first pick is unavailable or has started, refresh `get_last_minute` or `whats_on_tonight`, then live-check the next candidate. Do not call `get_related_experiences` from ChatGPT.
 
-## Show the results as cards
+## Show results as cards
 
-After `whats_on_tonight` / `get_last_minute` returns a set, call `render_experience_cards(experience_ids, render_context)` once — pass only the stable `t_` IDs, set `render_context.intent_summary` ("tonight in <city>"). The cards carry the countdown/urgency visually, so don't also re-list them as text.
+When a `whats_on_tonight` / `get_last_minute` set will be shown, immediately call `render_experience_cards` exactly once for it: stable `t_` IDs only, a required `render_type` from the callable schema, optionally `render_context.intent_summary` ("tonight in <city>"). Do not re-list the same experiences in text. Do not assume a particular field appears on the cards unless the renderer response confirms it.
 
-## Read the agent-intelligence metadata
+## Optional metadata
 
-- **_booking_urgency** — this is the star of this flow: surface "starts in 2h", "few seats left", "free cancellation" honestly and specifically. Never invent urgency.
-- **_best_picks** — lead with the soonest strong option, not the generically most_popular one.
-- **_next_step** / **_conversation_starters** — drive straight toward the booking link.
-
-## Conversation flow
-
-`whats_on_tonight` (or `get_last_minute`) → lead with the soonest 2-3 with their countdowns → the moment they pick one, check live availability for tonight and the party size → hand over the booking link → render cards once. Bias toward speed and honesty over breadth.
+Use fields documented by the selected tool and actually present in its response. Treat countdowns, remaining-seat hints and optional urgency metadata as preliminary — only a selected-product availability check supports an availability or scarcity claim.
 
 ## Etiquette
 
-- `format: "json"` when processing data; `format: "text"` for direct display.
-- Present everything as tickadoo — never name the underlying supplier.
-- Do NOT overstate availability. If the live check comes back sold out or past start time, say so and offer the nearest alternative.
-- Stale same-day availability is the most common failure here — if what you showed is gone or wrong at click time, send `report_quality_signal(request_id, ...)` with the `request_id` from the earlier call so tickadoo can tighten the feed.
+- Present everything as tickadoo. Never name, infer or expose an upstream inventory supplier.
+- State only the exact time, inventory, availability or cancellation fact returned by the latest relevant check. Review counts show popularity, not scarcity. Never add time pressure or sales pressure.
+- If the live check comes back sold out or past start time, say so plainly and offer the next candidate. If the user asks to continue, provide the tickadoo link and make clear any purchase completes outside ChatGPT.
+- If the user reports a stale or misleading result, offer to send feedback; only after they agree, call `report_quality_signal` with the originating `request_id`, the required `signal_type` and no personal data in notes (a write action).


### PR DESCRIPTION
## What this is

The "merge" Francis asked for: the `claudecode-web-howard` session's 7 Plugin Directory skills (branch `claude/optimistic-feynman-1wqasv`, 2 commits) plus a third commit applying every actionable finding from the Codex CLI skills review (all 7 were marked fix-first).

## Applied from the review

- **B2 renderer contract**: `render_type` required everywhere; render IMMEDIATELY after a renderer-supported discovery set (the 10 documented sources only; `compare_experiences`/`plan_itinerary`/`get_city_guide` explicitly non-renderable); once per set; `t_` ids only; no text re-listing.
- **B3**: `get_related_experiences` removed from all ChatGPT flows (reserved for non-ChatGPT clients).
- **B4**: `get_availability` (+`fresh`) is the basis of live claims; `check_availability` only for the date-specific link; composite plans check EVERY selected bookable slot or label unchecked ones as suggestions; "today" = venue-local date from `start_time` (S10).
- **B5**: `report_quality_signal` is consent-based, described as a write, uses `signal_type`, no personal data in notes.
- **B6**: all invalid params fixed (`sort`, `tags` array form, `mood: family_fun`, `list_cities` params, `to_latitude`/`to_longitude`, phantom search filters, `format`/`language` scope).
- **B7 + S5/N2**: all frontmatter descriptions replaced with the review's precedence-aware versions; general skill demoted to explicit fallback; volatile coverage counts removed.
- **S1-S9, N1, N3, N4** as written in the review.
- Removed the untracked `find-and-book-experiences` draft (a second catch-all competing with `tickadoo-experiences` in routing).

## NOT addressed (deliberately)

**B1 service-commerce eligibility** is a policy question for OpenAI, not a copy fix — needs Francis to obtain written confirmation. The interim neutral wording ("any purchase is completed outside ChatGPT") is applied throughout regardless.

## Validation

Frontmatter `name` matches folder for all 7; zero references to non-ChatGPT tools or removed params (grep-verified); every referenced tool exists in `server.json`'s 23-tool block. Bundle ZIP delivered to Francis for the Dashboard Skills upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FMf4BU1BaQ3j9jMLrvEhv

---
_Generated by [Claude Code](https://claude.ai/code/session_014FMf4BU1BaQ3j9jMLrvEhv)_