### PR TITLE
fix(discovery): align public MCP registry metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tickadoo",
-  "description": "Discover and book 13,090+ experiences across 700+ cities. 15 AI-powered tools for search, mood discovery, city guides, family planners, availability, and comparison.",
-  "version": "1.5.0",
+  "description": "Discover and book theatre, tours, attractions, and live experiences worldwide. Search, compare, check live availability, plan itineraries, and get direct tickadoo booking links. No API key required.",
+  "version": "2.0.0",
   "author": {
     "name": "tickadoo",
     "url": "https://tickadoo.com"

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -27,7 +27,7 @@ try {
   serverJson.version = packageJson.version;
   serverJson.title = "tickadoo Experiences and Events";
   serverJson.description =
-    "Discover and book theatre, tours, attractions, and live experiences across 681 cities worldwide. Search, recommend, check availability, compare, and plan itineraries, all presented as tickadoo. No API key required.";
+    "Discover and book theatre, tours, attractions, and live experiences worldwide. Search, compare, check live availability, plan itineraries, and get direct tickadoo booking links. No API key required.";
   serverJson.websiteUrl = "https://mcp.tickadoo.com";
   serverJson.remotes = [
     {

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -4,8 +4,8 @@ import { readFile, writeFile } from "node:fs/promises";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-const defaultRemoteUrl = "https://mcp.tickadoo.com/mcp";
-const remoteUrl = new URL(process.env.TICKADOO_MCP_URL || defaultRemoteUrl);
+const canonicalRemoteUrl = "https://mcp.tickadoo.com/mcp";
+const sourceRemoteUrl = new URL(process.env.TICKADOO_MCP_URL || canonicalRemoteUrl);
 const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
 const serverJsonUrl = new URL("../server.json", import.meta.url);
 const serverJson = JSON.parse(await readFile(serverJsonUrl, "utf8"));
@@ -21,7 +21,7 @@ const client = new Client(
 );
 
 try {
-  await client.connect(new StreamableHTTPClientTransport(remoteUrl));
+  await client.connect(new StreamableHTTPClientTransport(sourceRemoteUrl));
   const result = await client.listTools();
 
   serverJson.version = packageJson.version;
@@ -32,7 +32,7 @@ try {
   serverJson.remotes = [
     {
       type: "streamable-http",
-      url: remoteUrl.href,
+      url: canonicalRemoteUrl,
     },
   ];
   serverJson._meta["io.modelcontextprotocol.registry/publisher-provided"].tools =
@@ -43,7 +43,7 @@ try {
 
   await writeFile(serverJsonUrl, `${JSON.stringify(serverJson, null, 2)}\n`);
   console.log(
-    `Updated server.json with ${result.tools.length} tools from ${remoteUrl.href}`,
+    `Updated server.json with ${result.tools.length} tools from ${sourceRemoteUrl.href}`,
   );
 } finally {
   await client.close();

--- a/server.json
+++ b/server.json
@@ -101,7 +101,7 @@
   },
   "name": "io.github.tickadoo/tickadoo-mcp",
   "title": "tickadoo Experiences and Events",
-  "description": "Discover and book theatre, tours, attractions, and live experiences across 681 cities worldwide. Search, recommend, check availability, compare, and plan itineraries, all presented as tickadoo. No API key required.",
+  "description": "Discover and book theatre, tours, attractions, and live experiences worldwide. Search, compare, check live availability, plan itineraries, and get direct tickadoo booking links. No API key required.",
   "websiteUrl": "https://mcp.tickadoo.com",
   "repository": {
     "url": "https://github.com/tickadoo/tickadoo-mcp",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,7 +6,7 @@ build:
 metadata:
   name: "@tickadoo/mcp-server"
   displayName: "tickadoo — Experiences & Theatre"
-  description: "13,090+ bookable shows, theatre, tours, and attractions across 681 cities. Agent-native with best-picks, price-tiers, and conversation-starter intelligence."
+  description: "Discover and book theatre, tours, attractions, and live experiences worldwide. Search, compare, check live availability, plan itineraries, and get direct tickadoo booking links. No API key required."
   category: travel
   tags:
     - experiences

--- a/tests/metadata-consistency.test.ts
+++ b/tests/metadata-consistency.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const PUBLIC_DESCRIPTION =
+  "Discover and book theatre, tours, attractions, and live experiences worldwide. Search, compare, check live availability, plan itineraries, and get direct tickadoo booking links. No API key required.";
+const MCP_HOMEPAGE = "https://mcp.tickadoo.com";
+const MCP_ENDPOINT = `${MCP_HOMEPAGE}/mcp`;
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(
+    readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+  ) as T;
+}
+
+const packageJson = readJson<{
+  version: string;
+  repository: { url: string };
+}>("../package.json");
+const pluginJson = readJson<{
+  version: string;
+  description: string;
+  homepage: string;
+  repository: string;
+}>("../.claude-plugin/plugin.json");
+const serverJson = readJson<{
+  version: string;
+  description: string;
+  websiteUrl: string;
+  remotes: Array<{ type: string; url: string }>;
+}>("../server.json");
+const smitheryYaml = readFileSync(
+  new URL("../smithery.yaml", import.meta.url),
+  "utf8",
+);
+const syncScript = readFileSync(
+  new URL("../scripts/sync-server-json.mjs", import.meta.url),
+  "utf8",
+);
+
+describe("public registry metadata", () => {
+  it("keeps published versions aligned with package.json", () => {
+    expect(pluginJson.version).toBe(packageJson.version);
+    expect(serverJson.version).toBe(packageJson.version);
+  });
+
+  it("uses one evergreen, count-free public description", () => {
+    const smitheryDescription = smitheryYaml.match(
+      /^\s{2}description:\s+"([^"]+)"\s*$/m,
+    )?.[1];
+
+    expect(pluginJson.description).toBe(PUBLIC_DESCRIPTION);
+    expect(serverJson.description).toBe(PUBLIC_DESCRIPTION);
+    expect(smitheryDescription).toBe(PUBLIC_DESCRIPTION);
+    expect(syncScript).toContain(JSON.stringify(PUBLIC_DESCRIPTION));
+
+    for (const description of [
+      pluginJson.description,
+      serverJson.description,
+      smitheryDescription ?? "",
+    ]) {
+      expect(description).not.toMatch(
+        /\b\d[\d,]*\+?\s+(?:bookable\s+)?(?:products?|experiences?|cities|tools)\b/i,
+      );
+    }
+  });
+
+  it("keeps registry links on the canonical MCP service", () => {
+    expect(pluginJson.homepage).toBe(MCP_HOMEPAGE);
+    expect(pluginJson.repository).toBe(
+      packageJson.repository.url.replace(/\.git$/, ""),
+    );
+    expect(serverJson.websiteUrl).toBe(MCP_HOMEPAGE);
+    expect(serverJson.remotes).toEqual([
+      { type: "streamable-http", url: MCP_ENDPOINT },
+    ]);
+    expect(smitheryYaml).toMatch(
+      /^\s{2}url:\s+https:\/\/mcp\.tickadoo\.com\/mcp\s*$/m,
+    );
+    expect(smitheryYaml).toMatch(
+      /^\s{2}documentation:\s+https:\/\/mcp\.tickadoo\.com\/llms\.txt\s*$/m,
+    );
+  });
+});

--- a/tests/metadata-consistency.test.ts
+++ b/tests/metadata-consistency.test.ts
@@ -73,6 +73,8 @@ describe("public registry metadata", () => {
     expect(serverJson.remotes).toEqual([
       { type: "streamable-http", url: MCP_ENDPOINT },
     ]);
+    expect(syncScript).toContain("url: canonicalRemoteUrl");
+    expect(syncScript).not.toContain("url: sourceRemoteUrl.href");
     expect(smitheryYaml).toMatch(
       /^\s{2}url:\s+https:\/\/mcp\.tickadoo\.com\/mcp\s*$/m,
     );


### PR DESCRIPTION
## What changed

- Align the Claude plugin manifest with the repository package version `2.0.0`.
- Replace stale hard-coded catalogue and tool counts with one evergreen, conversion-led description across Claude, Smithery, and the MCP registry.
- Keep the server metadata generator on that same description so later syncs cannot reintroduce drift.
- Add focused consistency tests for versions, descriptions, canonical links, and the generator contract.

## Why

Public discovery metadata currently advertises conflicting versions and obsolete counts. That weakens trust at the point where agents and users decide whether to install or invoke tickadoo. Count-free copy stays accurate as the catalogue and tool set change.

The regenerated registry snapshot retains all 23 unique live tools.

## Validation

- `npm test`: 6 passed, 1 optional live test skipped
- `npx tsc --noEmit`: passed
- `npm run build`: passed
- Registry snapshot: 23 tools, 23 unique names
- `git diff --check`: passed

## Release note

This source merge does not publish a package or update external registries. npm currently serves `1.4.3`; publishing `2.0.0` and verifying MCP Registry, Smithery, and Claude directory propagation are separate release steps.

## Scope

Metadata and tests only. No website UI, layout, runtime bridge behavior, deployment, or Claude coordination files changed.