### PR TITLE
chore(deps): patch transitive nanoid advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2154,9 +2154,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- update the dev-only transitive `nanoid` lockfile resolution from 3.3.16 to patched 3.3.18
- preserve the existing dependency graph and package manifest
- clear GHSA-2v37-7h3g-55p8 without changing the production stdio bridge bundle

## Dependency path

`vitest -> vite -> postcss -> nanoid`

This dependency is used only for development and tests. `nanoid` is not present in the production bundle.

## Validation

- `npm audit`: 0 vulnerabilities
- full suite: 16 passed, 1 skipped
- Agent Plugins suite: 10 passed
- production build: passed
- production bundle exclusion scan: no `nanoid`
- `git diff --check`: clean

## Risk boundary

Routine lockfile-only dependency maintenance. No public MCP behavior, source code, manifest dependency, auth, credential, release, deployment, customer data, or production state change.

Linear: BAC-808